### PR TITLE
add whitelist start time

### DIFF
--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -18,7 +18,9 @@ use crate::msg::{
 };
 use crate::state::{Config, CONFIG, MINTABLE_TOKEN_IDS, SG721_ADDRESS};
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
-use whitelist::msg::{HasEndedResponse, HasMemberResponse, QueryMsg as WhitelistQueryMsg};
+use whitelist::msg::{
+    HasEndedResponse, HasMemberResponse, HasStartedResponse, QueryMsg as WhitelistQueryMsg,
+};
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:sg-minter";
@@ -212,14 +214,18 @@ pub fn execute_mint_sender(
     let config = CONFIG.load(deps.storage)?;
     let sg721_address = SG721_ADDRESS.load(deps.storage)?;
     let action = "mint_sender";
+    let mut pub_mint: bool = false;
 
     // check if a whitelist exists and not ended
     // sender has to be whitelisted to mint
     if let Some(whitelist) = config.whitelist {
-        let res: HasEndedResponse = deps
+        let res_started: HasStartedResponse = deps
+            .querier
+            .query_wasm_smart(whitelist.clone(), &WhitelistQueryMsg::HasStarted {})?;
+        let res_ended: HasEndedResponse = deps
             .querier
             .query_wasm_smart(whitelist.clone(), &WhitelistQueryMsg::HasEnded {})?;
-        if !res.has_ended {
+        if res_started.has_started && !res_ended.has_ended {
             let res: HasMemberResponse = deps.querier.query_wasm_smart(
                 whitelist,
                 &WhitelistQueryMsg::HasMember {
@@ -231,13 +237,20 @@ pub fn execute_mint_sender(
                     addr: info.sender.to_string(),
                 });
             }
+        } else {
+            pub_mint = true;
         }
+    } else {
+        pub_mint = true;
     }
 
-    if let Some(start_time) = config.start_time {
-        // Check if after start_time
-        if !start_time.is_expired(&env.block) {
-            return Err(ContractError::BeforeMintStartTime {});
+    // if there is no active whitelist right now, check public mint
+    if pub_mint == true {
+        if let Some(start_time) = config.start_time {
+            // Check if after start_time
+            if !start_time.is_expired(&env.block) {
+                return Err(ContractError::BeforeMintStartTime {});
+            }
         }
     }
 

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -245,7 +245,7 @@ pub fn execute_mint_sender(
     }
 
     // if there is no active whitelist right now, check public mint
-    if pub_mint == true {
+    if pub_mint {
         if let Some(start_time) = config.start_time {
             // Check if after start_time
             if !start_time.is_expired(&env.block) {

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -440,6 +440,15 @@ fn whitelist_access_len_add_remove_expiration() {
     );
     assert!(res.is_ok());
 
+    let wl_msg = WhitelistExecuteMsg::UpdateStartTime(Expiration::AtTime(Timestamp::from_nanos(0)));
+    let res = router.execute_contract(
+        creator.clone(),
+        whitelist_addr.clone(),
+        &wl_msg,
+        &coins(PRICE, NATIVE_DENOM),
+    );
+    assert!(res.is_ok());
+
     // set whitelist in minter contract
     let set_whitelist_msg = ExecuteMsg::SetWhitelist {
         whitelist: whitelist_addr.to_string(),

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -7,7 +7,7 @@ use cw_utils::Expiration;
 use sg721::msg::InstantiateMsg as Sg721InstantiateMsg;
 use sg721::state::{Config, RoyaltyInfo};
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
-// use whitelist::msg::InstantiateMsg as WhitelistInstantiateMsg;
+use whitelist::msg::InstantiateMsg as WhitelistInstantiateMsg;
 // use whitelist::msg::{ExecuteMsg as WhitelistExecuteMsg, UpdateMembersMsg};
 
 use crate::contract::instantiate;
@@ -27,14 +27,14 @@ fn mock_app() -> App {
     App::default()
 }
 
-// pub fn contract_whitelist() -> Box<dyn Contract<Empty>> {
-//     let contract = ContractWrapper::new(
-//         whitelist::contract::execute,
-//         whitelist::contract::instantiate,
-//         whitelist::contract::query,
-//     );
-//     Box::new(contract)
-// }
+pub fn contract_whitelist() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        whitelist::contract::execute,
+        whitelist::contract::instantiate,
+        whitelist::contract::query,
+    );
+    Box::new(contract)
+}
 
 pub fn contract_minter() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new(
@@ -55,26 +55,27 @@ pub fn contract_sg721() -> Box<dyn Contract<Empty>> {
     Box::new(contract)
 }
 
-// fn setup_whitelist_contract(router: &mut App, creator: &Addr) -> Result<Addr, ContractError> {
-//     let whitelist_code_id = router.store_code(contract_whitelist());
+fn setup_whitelist_contract(router: &mut App, creator: &Addr) -> Result<Addr, ContractError> {
+    let whitelist_code_id = router.store_code(contract_whitelist());
 
-//     let msg = WhitelistInstantiateMsg {
-//         members: vec![],
-//         end_time: Expiration::Never {},
-//     };
-//     let whitelist_addr = router
-//         .instantiate_contract(
-//             whitelist_code_id,
-//             creator.clone(),
-//             &msg,
-//             &[],
-//             "whitelist",
-//             None,
-//         )
-//         .unwrap();
+    let msg = WhitelistInstantiateMsg {
+        members: vec![],
+        start_time: Expiration::Never {},
+        end_time: Expiration::Never {},
+    };
+    let whitelist_addr = router
+        .instantiate_contract(
+            whitelist_code_id,
+            creator.clone(),
+            &msg,
+            &[],
+            "whitelist",
+            None,
+        )
+        .unwrap();
 
-//     Ok(whitelist_addr)
-// }
+    Ok(whitelist_addr)
+}
 
 // Upload contract code and instantiate sale contract
 fn setup_minter_contract(

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -7,7 +7,7 @@ use cw_utils::Expiration;
 use sg721::msg::InstantiateMsg as Sg721InstantiateMsg;
 use sg721::state::{Config, RoyaltyInfo};
 use sg_std::{GENESIS_MINT_START_TIME, NATIVE_DENOM};
-use whitelist::msg::InstantiateMsg as WhitelistInstantiateMsg;
+// use whitelist::msg::InstantiateMsg as WhitelistInstantiateMsg;
 // use whitelist::msg::{ExecuteMsg as WhitelistExecuteMsg, UpdateMembersMsg};
 
 use crate::contract::instantiate;
@@ -27,14 +27,14 @@ fn mock_app() -> App {
     App::default()
 }
 
-pub fn contract_whitelist() -> Box<dyn Contract<Empty>> {
-    let contract = ContractWrapper::new(
-        whitelist::contract::execute,
-        whitelist::contract::instantiate,
-        whitelist::contract::query,
-    );
-    Box::new(contract)
-}
+// pub fn contract_whitelist() -> Box<dyn Contract<Empty>> {
+//     let contract = ContractWrapper::new(
+//         whitelist::contract::execute,
+//         whitelist::contract::instantiate,
+//         whitelist::contract::query,
+//     );
+//     Box::new(contract)
+// }
 
 pub fn contract_minter() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new(
@@ -55,27 +55,26 @@ pub fn contract_sg721() -> Box<dyn Contract<Empty>> {
     Box::new(contract)
 }
 
-fn setup_whitelist_contract(router: &mut App, creator: &Addr) -> Result<Addr, ContractError> {
-    let whitelist_code_id = router.store_code(contract_whitelist());
+// fn setup_whitelist_contract(router: &mut App, creator: &Addr) -> Result<Addr, ContractError> {
+//     let whitelist_code_id = router.store_code(contract_whitelist());
 
-    let msg = WhitelistInstantiateMsg {
-        members: vec![],
-        start_time: Expiration::Never {},
-        end_time: Expiration::Never {},
-    };
-    let whitelist_addr = router
-        .instantiate_contract(
-            whitelist_code_id,
-            creator.clone(),
-            &msg,
-            &[],
-            "whitelist",
-            None,
-        )
-        .unwrap();
+//     let msg = WhitelistInstantiateMsg {
+//         members: vec![],
+//         end_time: Expiration::Never {},
+//     };
+//     let whitelist_addr = router
+//         .instantiate_contract(
+//             whitelist_code_id,
+//             creator.clone(),
+//             &msg,
+//             &[],
+//             "whitelist",
+//             None,
+//         )
+//         .unwrap();
 
-    Ok(whitelist_addr)
-}
+//     Ok(whitelist_addr)
+// }
 
 // Upload contract code and instantiate sale contract
 fn setup_minter_contract(


### PR DESCRIPTION
Creators build a community whitelist, add `addresses`, `start_time`, `end_time`. These whitelist addresses can mint before public mint.

`minter` contract should allow for multiple whitelists, a whitelist `start_time` before public mint `start_time`

flow: `if whitelist { check on whitelist } else {check public mint}`