### PR TITLE
Yubrew/67 creators have free mints for mint_to and mint_for

### DIFF
--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -403,6 +403,7 @@ fn _execute_mint(
     let network_fee = mint_price.amount * fee_percent;
     println!("network fee, {}", network_fee);
     let network_fee_msg = burn_and_distribute_fee(env, &info, network_fee.u128())?;
+    println!("after network fee, {}", network_fee);
 
     // if token_id None, find and assign one. else check token_id exists on mintable map.
     let mintable_token_id: u64 = if token_id.is_none() {

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -40,7 +40,7 @@ const STARTING_BATCH_MINT_LIMIT: u64 = 5;
 const STARTING_PER_ADDRESS_LIMIT: u64 = 5;
 const MIN_MINT_PRICE: u128 = 50_000_000;
 const MINT_FEE_PERCENT: u64 = 10;
-const ADMIN_MINT_PRICE: u128 = 1;
+const ADMIN_MINT_PRICE: u128 = 0;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -395,8 +395,8 @@ fn _execute_mint(
         ));
     }
 
-    // guardrail against low mint price updates for non-admins
-    if MIN_MINT_PRICE > mint_price.amount.into() && info.sender != config.admin {
+    // guardrail against low mint price updates
+    if MIN_MINT_PRICE > mint_price.amount.into() && !admin_no_fee {
         return Err(ContractError::InsufficientMintPrice {
             expected: MIN_MINT_PRICE,
             got: mint_price.amount.into(),

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -403,8 +403,8 @@ fn _execute_mint(
         });
     }
 
+    // create network fee msgs
     let mut network_fee_msgs: Vec<CosmosMsg<StargazeMsgWrapper>> = vec![];
-
     let network_fee: Uint128 = if admin_no_fee {
         Uint128::zero()
     } else {
@@ -437,15 +437,14 @@ fn _execute_mint(
         return Err(ContractError::InvalidTokenId {});
     };
 
+    // create mint msgs
     let mut msgs: Vec<CosmosMsg<StargazeMsgWrapper>> = vec![];
-
     let mint_msg = Cw721ExecuteMsg::Mint(MintMsg::<Empty> {
         token_id: mintable_token_id.to_string(),
         owner: recipient_addr.to_string(),
         token_uri: Some(format!("{}/{}", config.base_token_uri, mintable_token_id)),
         extension: Empty {},
     });
-
     let msg = CosmosMsg::Wasm(WasmMsg::Execute {
         contract_addr: sg721_address.to_string(),
         msg: to_binary(&mint_msg)?,

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -386,10 +386,8 @@ fn _execute_mint(
     };
 
     let mint_price: Coin = mint_price(deps.as_ref(), admin_no_fee)?;
-    println!("_execute_mint mint price {}", mint_price);
     // exact payment only
     let payment = may_pay(&info, &config.unit_price.denom)?;
-    println!("_execute_mint payment {}", payment);
     if payment != mint_price.amount {
         return Err(ContractError::IncorrectPaymentAmount(
             coin(payment.u128(), &config.unit_price.denom),
@@ -404,8 +402,6 @@ fn _execute_mint(
             got: mint_price.amount.into(),
         });
     }
-
-    println!("got through mint fee and payment checks");
 
     let mut network_fee_msgs: Vec<CosmosMsg<StargazeMsgWrapper>> = vec![];
 

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -460,10 +460,10 @@ fn _execute_mint(
 
     if !admin_no_fee {
         let seller_amount = mint_price.amount - network_fee;
-        msgs.append(&mut vec![BankMsg::Send {
+        msgs.append(&mut vec![CosmosMsg::Bank(BankMsg::Send {
             to_address: config.admin.to_string(),
             amount: vec![coin(seller_amount.u128(), config.unit_price.denom)],
-        }]);
+        })]);
     };
 
     Ok(Response::default()

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -25,7 +25,7 @@ const UNIT_PRICE: u128 = 100_000_000;
 const MINT_FEE: u128 = 10_000_000;
 const MAX_TOKEN_LIMIT: u32 = 10000;
 const WHITELIST_AMOUNT: u128 = 66_000_000;
-const ADMIN_MINT_PRICE: u128 = 1;
+const ADMIN_MINT_PRICE: u128 = 0;
 
 fn custom_mock_app() -> StargazeApp {
     StargazeApp::default()

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -25,7 +25,7 @@ const UNIT_PRICE: u128 = 100_000_000;
 const MINT_FEE: u128 = 10_000_000;
 const MAX_TOKEN_LIMIT: u32 = 10000;
 const WHITELIST_AMOUNT: u128 = 66_000_000;
-const ADMIN_MINT_PRICE: u128 = 0;
+const ADMIN_MINT_PRICE: u128 = 1;
 
 fn custom_mock_app() -> StargazeApp {
     StargazeApp::default()

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -966,11 +966,12 @@ fn mint_for_token_id_addr() {
         minter_addr.clone(),
         &batch_mint_msg,
         &coins_for_msg(Coin {
-            amount: Uint128::from(ADMIN_MINT_PRICE),
+            amount: Uint128::from(UNIT_PRICE * num_mints as u128),
             denom: NATIVE_DENOM.to_string(),
         }),
     );
     assert!(res.is_ok());
+
     let mintable_num_tokens_response: MintableNumTokensResponse = router
         .wrap()
         .query_wasm_smart(minter_addr, &QueryMsg::MintableNumTokens {})

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -381,7 +381,7 @@ fn happy_path() {
         .unwrap();
     assert_eq!(res.owner, buyer.to_string());
 
-    // // Buyer can't call MintTo
+    // Buyer can't call MintTo
     let mint_to_msg = ExecuteMsg::MintTo {
         recipient: buyer.clone(),
     };

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -337,64 +337,64 @@ fn happy_path() {
     );
 
     // Fail with incorrect tokens
-    let mint_msg = ExecuteMsg::Mint {};
-    let err = router.execute_contract(
-        buyer.clone(),
-        minter_addr.clone(),
-        &mint_msg,
-        &coins(UNIT_PRICE + 100, NATIVE_DENOM),
-    );
-    assert!(err.is_err());
+    // let mint_msg = ExecuteMsg::Mint {};
+    // let err = router.execute_contract(
+    //     buyer.clone(),
+    //     minter_addr.clone(),
+    //     &mint_msg,
+    //     &coins(UNIT_PRICE + 100, NATIVE_DENOM),
+    // );
+    // assert!(err.is_err());
 
-    // Succeeds if funds are sent
-    let mint_msg = ExecuteMsg::Mint {};
-    let res = router.execute_contract(
-        buyer.clone(),
-        minter_addr.clone(),
-        &mint_msg,
-        &coins(UNIT_PRICE, NATIVE_DENOM),
-    );
-    assert!(res.is_ok());
+    // // Succeeds if funds are sent
+    // let mint_msg = ExecuteMsg::Mint {};
+    // let res = router.execute_contract(
+    //     buyer.clone(),
+    //     minter_addr.clone(),
+    //     &mint_msg,
+    //     &coins(UNIT_PRICE, NATIVE_DENOM),
+    // );
+    // assert!(res.is_ok());
 
-    // Balances are correct
-    // The creator should get the unit price - mint fee for the mint above
-    let creator_balances = router.wrap().query_all_balances(creator.clone()).unwrap();
-    assert_eq!(
-        creator_balances,
-        coins(INITIAL_BALANCE + UNIT_PRICE - MINT_FEE, NATIVE_DENOM)
-    );
-    // The buyer's tokens should reduce by unit price
-    let buyer_balances = router.wrap().query_all_balances(buyer.clone()).unwrap();
-    assert_eq!(
-        buyer_balances,
-        coins(INITIAL_BALANCE - UNIT_PRICE, NATIVE_DENOM)
-    );
+    // // Balances are correct
+    // // The creator should get the unit price - mint fee for the mint above
+    // let creator_balances = router.wrap().query_all_balances(creator.clone()).unwrap();
+    // assert_eq!(
+    //     creator_balances,
+    //     coins(INITIAL_BALANCE + UNIT_PRICE - MINT_FEE, NATIVE_DENOM)
+    // );
+    // // The buyer's tokens should reduce by unit price
+    // let buyer_balances = router.wrap().query_all_balances(buyer.clone()).unwrap();
+    // assert_eq!(
+    //     buyer_balances,
+    //     coins(INITIAL_BALANCE - UNIT_PRICE, NATIVE_DENOM)
+    // );
 
-    // Check NFT is transferred
-    let query_owner_msg = Cw721QueryMsg::OwnerOf {
-        token_id: String::from("1"),
-        include_expired: None,
-    };
-    let res: OwnerOfResponse = router
-        .wrap()
-        .query_wasm_smart(config.sg721_address.clone(), &query_owner_msg)
-        .unwrap();
-    assert_eq!(res.owner, buyer.to_string());
+    // // Check NFT is transferred
+    // let query_owner_msg = Cw721QueryMsg::OwnerOf {
+    //     token_id: String::from("1"),
+    //     include_expired: None,
+    // };
+    // let res: OwnerOfResponse = router
+    //     .wrap()
+    //     .query_wasm_smart(config.sg721_address.clone(), &query_owner_msg)
+    //     .unwrap();
+    // assert_eq!(res.owner, buyer.to_string());
 
-    // Buyer can't call MintTo
+    // // Buyer can't call MintTo
     let mint_to_msg = ExecuteMsg::MintTo {
         recipient: buyer.clone(),
     };
-    let res = router.execute_contract(
-        buyer.clone(),
-        minter_addr.clone(),
-        &mint_to_msg,
-        &coins_for_msg(Coin {
-            amount: Uint128::from(ADMIN_MINT_PRICE),
-            denom: NATIVE_DENOM.to_string(),
-        }),
-    );
-    assert!(res.is_err());
+    // let res = router.execute_contract(
+    //     buyer.clone(),
+    //     minter_addr.clone(),
+    //     &mint_to_msg,
+    //     &coins_for_msg(Coin {
+    //         amount: Uint128::from(ADMIN_MINT_PRICE),
+    //         denom: NATIVE_DENOM.to_string(),
+    //     }),
+    // );
+    // assert!(res.is_err());
 
     // Creator mints an extra NFT for the buyer (who is a friend)
     let res = router.execute_contract(

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -380,7 +380,10 @@ fn happy_path() {
 
     // Creator mints an extra NFT for the buyer (who is a friend)
     let res = router.execute_contract(creator.clone(), minter_addr.clone(), &mint_to_msg, &vec![]);
-    assert!(res.is_ok());
+    let err = res.unwrap_err();
+    println!("{}", err.source().unwrap().to_string());
+    assert!(false);
+    // assert!(res.is_ok());
 
     // minter contract should have no balance
     let minter_balance = router

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -375,21 +375,11 @@ fn happy_path() {
     let mint_to_msg = ExecuteMsg::MintTo {
         recipient: buyer.clone(),
     };
-    let res = router.execute_contract(
-        buyer.clone(),
-        minter_addr.clone(),
-        &mint_to_msg,
-        &coins(UNIT_PRICE, NATIVE_DENOM),
-    );
+    let res = router.execute_contract(buyer.clone(), minter_addr.clone(), &mint_to_msg, &vec![]);
     assert!(res.is_err());
 
     // Creator mints an extra NFT for the buyer (who is a friend)
-    let res = router.execute_contract(
-        creator.clone(),
-        minter_addr.clone(),
-        &mint_to_msg,
-        &coins(UNIT_PRICE, NATIVE_DENOM),
-    );
+    let res = router.execute_contract(creator.clone(), minter_addr.clone(), &mint_to_msg, &vec![]);
     assert!(res.is_ok());
 
     // minter contract should have no balance
@@ -420,13 +410,8 @@ fn happy_path() {
     );
     assert!(res.is_err());
 
-    // Creator can't use MintFor if sold out
-    let res = router.execute_contract(
-        creator,
-        minter_addr,
-        &mint_to_msg,
-        &coins(UNIT_PRICE, NATIVE_DENOM),
-    );
+    // Creator can't use MintTo if sold out
+    let res = router.execute_contract(creator, minter_addr, &mint_to_msg, &vec![]);
     assert!(res.is_err());
 }
 
@@ -860,12 +845,7 @@ fn mint_for_token_id_addr() {
         recipient: buyer.clone(),
     };
     let err = router
-        .execute_contract(
-            buyer.clone(),
-            minter_addr.clone(),
-            &mint_for_msg,
-            &coins(UNIT_PRICE, NATIVE_DENOM),
-        )
+        .execute_contract(buyer.clone(), minter_addr.clone(), &mint_for_msg, &vec![])
         .unwrap_err();
     assert_eq!(
         err.source().unwrap().to_string(),
@@ -897,12 +877,7 @@ fn mint_for_token_id_addr() {
         recipient: buyer.clone(),
     };
     let err = router
-        .execute_contract(
-            creator.clone(),
-            minter_addr.clone(),
-            &mint_for_msg,
-            &coins(UNIT_PRICE, NATIVE_DENOM),
-        )
+        .execute_contract(creator.clone(), minter_addr.clone(), &mint_for_msg, &vec![])
         .unwrap_err();
     assert_eq!(
         ContractError::TokenIdAlreadySold { token_id }.to_string(),
@@ -920,22 +895,12 @@ fn mint_for_token_id_addr() {
         token_id,
         recipient: buyer,
     };
-    let res = router.execute_contract(
-        creator.clone(),
-        minter_addr.clone(),
-        &mint_for_msg,
-        &coins(UNIT_PRICE, NATIVE_DENOM),
-    );
+    let res = router.execute_contract(creator.clone(), minter_addr.clone(), &mint_for_msg, &vec![]);
     assert!(res.is_ok());
 
     let num_mints = 2;
     let batch_mint_msg = ExecuteMsg::BatchMint { num_mints };
-    let res = router.execute_contract(
-        creator,
-        minter_addr.clone(),
-        &batch_mint_msg,
-        &coins(UNIT_PRICE * num_mints as u128, NATIVE_DENOM),
-    );
+    let res = router.execute_contract(creator, minter_addr.clone(), &batch_mint_msg, &vec![]);
     assert!(res.is_ok());
     let mintable_num_tokens_response: MintableNumTokensResponse = router
         .wrap()

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -337,64 +337,64 @@ fn happy_path() {
     );
 
     // Fail with incorrect tokens
-    // let mint_msg = ExecuteMsg::Mint {};
-    // let err = router.execute_contract(
-    //     buyer.clone(),
-    //     minter_addr.clone(),
-    //     &mint_msg,
-    //     &coins(UNIT_PRICE + 100, NATIVE_DENOM),
-    // );
-    // assert!(err.is_err());
+    let mint_msg = ExecuteMsg::Mint {};
+    let err = router.execute_contract(
+        buyer.clone(),
+        minter_addr.clone(),
+        &mint_msg,
+        &coins(UNIT_PRICE + 100, NATIVE_DENOM),
+    );
+    assert!(err.is_err());
 
-    // // Succeeds if funds are sent
-    // let mint_msg = ExecuteMsg::Mint {};
-    // let res = router.execute_contract(
-    //     buyer.clone(),
-    //     minter_addr.clone(),
-    //     &mint_msg,
-    //     &coins(UNIT_PRICE, NATIVE_DENOM),
-    // );
-    // assert!(res.is_ok());
+    // Succeeds if funds are sent
+    let mint_msg = ExecuteMsg::Mint {};
+    let res = router.execute_contract(
+        buyer.clone(),
+        minter_addr.clone(),
+        &mint_msg,
+        &coins(UNIT_PRICE, NATIVE_DENOM),
+    );
+    assert!(res.is_ok());
 
-    // // Balances are correct
-    // // The creator should get the unit price - mint fee for the mint above
-    // let creator_balances = router.wrap().query_all_balances(creator.clone()).unwrap();
-    // assert_eq!(
-    //     creator_balances,
-    //     coins(INITIAL_BALANCE + UNIT_PRICE - MINT_FEE, NATIVE_DENOM)
-    // );
-    // // The buyer's tokens should reduce by unit price
-    // let buyer_balances = router.wrap().query_all_balances(buyer.clone()).unwrap();
-    // assert_eq!(
-    //     buyer_balances,
-    //     coins(INITIAL_BALANCE - UNIT_PRICE, NATIVE_DENOM)
-    // );
+    // Balances are correct
+    // The creator should get the unit price - mint fee for the mint above
+    let creator_balances = router.wrap().query_all_balances(creator.clone()).unwrap();
+    assert_eq!(
+        creator_balances,
+        coins(INITIAL_BALANCE + UNIT_PRICE - MINT_FEE, NATIVE_DENOM)
+    );
+    // The buyer's tokens should reduce by unit price
+    let buyer_balances = router.wrap().query_all_balances(buyer.clone()).unwrap();
+    assert_eq!(
+        buyer_balances,
+        coins(INITIAL_BALANCE - UNIT_PRICE, NATIVE_DENOM)
+    );
 
-    // // Check NFT is transferred
-    // let query_owner_msg = Cw721QueryMsg::OwnerOf {
-    //     token_id: String::from("1"),
-    //     include_expired: None,
-    // };
-    // let res: OwnerOfResponse = router
-    //     .wrap()
-    //     .query_wasm_smart(config.sg721_address.clone(), &query_owner_msg)
-    //     .unwrap();
-    // assert_eq!(res.owner, buyer.to_string());
+    // Check NFT is transferred
+    let query_owner_msg = Cw721QueryMsg::OwnerOf {
+        token_id: String::from("1"),
+        include_expired: None,
+    };
+    let res: OwnerOfResponse = router
+        .wrap()
+        .query_wasm_smart(config.sg721_address.clone(), &query_owner_msg)
+        .unwrap();
+    assert_eq!(res.owner, buyer.to_string());
 
     // // Buyer can't call MintTo
     let mint_to_msg = ExecuteMsg::MintTo {
         recipient: buyer.clone(),
     };
-    // let res = router.execute_contract(
-    //     buyer.clone(),
-    //     minter_addr.clone(),
-    //     &mint_to_msg,
-    //     &coins_for_msg(Coin {
-    //         amount: Uint128::from(ADMIN_MINT_PRICE),
-    //         denom: NATIVE_DENOM.to_string(),
-    //     }),
-    // );
-    // assert!(res.is_err());
+    let res = router.execute_contract(
+        buyer.clone(),
+        minter_addr.clone(),
+        &mint_to_msg,
+        &coins_for_msg(Coin {
+            amount: Uint128::from(ADMIN_MINT_PRICE),
+            denom: NATIVE_DENOM.to_string(),
+        }),
+    );
+    assert!(res.is_err());
 
     // Creator mints an extra NFT for the buyer (who is a friend)
     let res = router.execute_contract(
@@ -406,10 +406,7 @@ fn happy_path() {
             denom: NATIVE_DENOM.to_string(),
         }),
     );
-    let err = res.unwrap_err();
-    println!("{}", err.source().unwrap().to_string());
-    assert!(false);
-    // assert!(res.is_ok());
+    assert!(res.is_ok());
 
     // minter contract should have no balance
     let minter_balance = router

--- a/packages/sg-std/src/fees.rs
+++ b/packages/sg-std/src/fees.rs
@@ -1,6 +1,6 @@
 use crate::{create_fund_community_pool_msg, StargazeMsgWrapper, NATIVE_DENOM};
 use cosmwasm_std::{coins, BankMsg, CosmosMsg, Decimal, Env, MessageInfo, Uint128};
-use cw_utils::{may_pay, PaymentError};
+use cw_utils::{must_pay, PaymentError};
 use thiserror::Error;
 
 // governance parameters
@@ -12,7 +12,7 @@ pub fn burn_and_distribute_fee(
     info: &MessageInfo,
     fee_amount: u128,
 ) -> Result<Vec<SubMsg>, FeeError> {
-    let payment = may_pay(info, NATIVE_DENOM)?;
+    let payment = must_pay(info, NATIVE_DENOM)?;
     if payment.u128() < fee_amount {
         return Err(FeeError::InsufficientFee(fee_amount, payment.u128()));
     };

--- a/packages/sg-std/src/fees.rs
+++ b/packages/sg-std/src/fees.rs
@@ -1,10 +1,20 @@
 use crate::{create_fund_community_pool_msg, StargazeMsgWrapper, NATIVE_DENOM};
-use cosmwasm_std::{coin, coins, BankMsg, CosmosMsg, Decimal, Env, MessageInfo, Uint128};
+use cosmwasm_std::{coin, BankMsg, Coin, CosmosMsg, Decimal, Env, MessageInfo, Uint128};
 use cw_utils::{must_pay, PaymentError};
 use thiserror::Error;
 
 // governance parameters
 const FEE_BURN_PERCENT: u64 = 50;
+
+// deal with zero and non-zero coin amounts for msgs
+fn convert_coins_for_msg(msg_coin: Coin) -> Vec<Coin> {
+    if msg_coin.amount > Uint128::zero() {
+        vec![msg_coin]
+    } else {
+        println!("sg-std fees: no funds sent");
+        vec![]
+    }
+}
 
 type SubMsg = CosmosMsg<StargazeMsgWrapper>;
 pub fn burn_and_distribute_fee(
@@ -23,12 +33,17 @@ pub fn burn_and_distribute_fee(
     let burn_coin = coin(burn_fee.u128(), NATIVE_DENOM);
     // burn half the fee
     let fee_burn_msg = BankMsg::Burn {
-        amount: vec![burn_coin],
+        amount: convert_coins_for_msg(burn_coin),
     };
+    println!("fee burn msg: {:?}", fee_burn_msg);
 
     // Send other half to community pool
-    let fund_community_pool_msg =
-        create_fund_community_pool_msg(coins(fee_amount - burn_fee.u128(), NATIVE_DENOM));
+    let fund_community_pool_msg = create_fund_community_pool_msg(convert_coins_for_msg(coin(
+        fee_amount - burn_fee.u128(),
+        NATIVE_DENOM,
+    )));
+
+    println!("fund community pool msg: {:?}", fund_community_pool_msg);
 
     Ok(vec![CosmosMsg::Bank(fee_burn_msg), fund_community_pool_msg])
 }

--- a/packages/sg-std/src/fees.rs
+++ b/packages/sg-std/src/fees.rs
@@ -12,25 +12,21 @@ pub fn burn_and_distribute_fee(
     info: &MessageInfo,
     fee_amount: u128,
 ) -> Result<Vec<SubMsg>, FeeError> {
-    println!("inside burn and distribute fee");
     let payment = may_pay(info, NATIVE_DENOM)?;
     if payment.u128() < fee_amount {
         return Err(FeeError::InsufficientFee(fee_amount, payment.u128()));
     };
 
     // calculate the fee to burn
+    // burn half the fee
     let burn_percent = Decimal::percent(FEE_BURN_PERCENT);
     let burn_fee = Uint128::from(fee_amount) * burn_percent;
     let burn_coin = coins(burn_fee.u128(), NATIVE_DENOM);
-    // burn half the fee
     let fee_burn_msg = BankMsg::Burn { amount: burn_coin };
-    println!("fee burn msg: {:?}", fee_burn_msg);
 
     // Send other half to community pool
     let fund_community_pool_msg =
         create_fund_community_pool_msg(coins(fee_amount - burn_fee.u128(), NATIVE_DENOM));
-
-    println!("fund community pool msg: {:?}", fund_community_pool_msg);
 
     Ok(vec![CosmosMsg::Bank(fee_burn_msg), fund_community_pool_msg])
 }

--- a/packages/sg-std/src/fees.rs
+++ b/packages/sg-std/src/fees.rs
@@ -1,20 +1,10 @@
 use crate::{create_fund_community_pool_msg, StargazeMsgWrapper, NATIVE_DENOM};
-use cosmwasm_std::{coin, coins, BankMsg, Coin, CosmosMsg, Decimal, Env, MessageInfo, Uint128};
+use cosmwasm_std::{coins, BankMsg, CosmosMsg, Decimal, Env, MessageInfo, Uint128};
 use cw_utils::{may_pay, PaymentError};
 use thiserror::Error;
 
 // governance parameters
 const FEE_BURN_PERCENT: u64 = 50;
-
-// deal with zero and non-zero coin amounts for msgs
-fn convert_coins_for_msg(msg_coin: Coin) -> Vec<Coin> {
-    if msg_coin.amount > Uint128::zero() {
-        vec![msg_coin]
-    } else {
-        println!("sg-std fees: no funds sent");
-        coins(0, NATIVE_DENOM)
-    }
-}
 
 type SubMsg = CosmosMsg<StargazeMsgWrapper>;
 pub fn burn_and_distribute_fee(
@@ -28,26 +18,17 @@ pub fn burn_and_distribute_fee(
         return Err(FeeError::InsufficientFee(fee_amount, payment.u128()));
     };
 
-    println!("before burn calc");
     // calculate the fee to burn
     let burn_percent = Decimal::percent(FEE_BURN_PERCENT);
     let burn_fee = Uint128::from(fee_amount) * burn_percent;
-    let burn_coin = coin(burn_fee.u128(), NATIVE_DENOM);
+    let burn_coin = coins(burn_fee.u128(), NATIVE_DENOM);
     // burn half the fee
-    println!(
-        "fee burn msg: {:?}",
-        convert_coins_for_msg(burn_coin.clone())
-    );
-    let fee_burn_msg = BankMsg::Burn {
-        amount: convert_coins_for_msg(burn_coin),
-    };
+    let fee_burn_msg = BankMsg::Burn { amount: burn_coin };
     println!("fee burn msg: {:?}", fee_burn_msg);
 
     // Send other half to community pool
-    let fund_community_pool_msg = create_fund_community_pool_msg(convert_coins_for_msg(coin(
-        fee_amount - burn_fee.u128(),
-        NATIVE_DENOM,
-    )));
+    let fund_community_pool_msg =
+        create_fund_community_pool_msg(coins(fee_amount - burn_fee.u128(), NATIVE_DENOM));
 
     println!("fund community pool msg: {:?}", fund_community_pool_msg);
 


### PR DESCRIPTION
fix #67 
`creator` can mint for free using `mint_for` and `mint_to`

`_execute_mint` has an extra param `admin_no_fee: true` passed by `mint_for` and `mint_to`

this skips `community_fund`, `burn`, and `seller` messages because price is 0