### PR TITLE
add whitelist per_address_limit

### DIFF
--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -583,7 +583,7 @@ pub fn mint_price(deps: Deps, admin_no_fee: bool) -> Result<Coin, StdError> {
     } else if let Some(whitelist) = config.whitelist {
         let wl_config: WhitelistConfigResponse = deps
             .querier
-            .query_wasm_smart(whitelist.clone(), &WhitelistQueryMsg::Config {})?;
+            .query_wasm_smart(whitelist, &WhitelistQueryMsg::Config {})?;
         if wl_config.is_active {
             wl_config.unit_price
         } else {

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -19,7 +19,8 @@ use crate::msg::{
 use crate::state::{Config, CONFIG, MINTABLE_TOKEN_IDS, SG721_ADDRESS};
 use sg_std::{burn_and_distribute_fee, StargazeMsgWrapper, GENESIS_MINT_START_TIME, NATIVE_DENOM};
 use whitelist::msg::{
-    HasMemberResponse, IsActiveResponse, QueryMsg as WhitelistQueryMsg, UnitPriceResponse,
+    ConfigResponse as WhitelistConfigResponse, HasMemberResponse, QueryMsg as WhitelistQueryMsg,
+    UnitPriceResponse,
 };
 
 pub type Response = cosmwasm_std::Response<StargazeMsgWrapper>;
@@ -226,10 +227,11 @@ pub fn execute_mint_sender(
     // check if a whitelist exists and not ended
     // sender has to be whitelisted to mint
     if let Some(whitelist) = config.whitelist {
-        let res_is_active: IsActiveResponse = deps
+        let wl_config: WhitelistConfigResponse = deps
             .querier
-            .query_wasm_smart(whitelist.clone(), &WhitelistQueryMsg::IsActive {})?;
-        if res_is_active.is_active {
+            .query_wasm_smart(whitelist.clone(), &WhitelistQueryMsg::Config {})?;
+
+        if wl_config.is_active {
             let res: HasMemberResponse = deps.querier.query_wasm_smart(
                 whitelist,
                 &WhitelistQueryMsg::HasMember {
@@ -240,6 +242,18 @@ pub fn execute_mint_sender(
                 return Err(ContractError::NotWhitelisted {
                     addr: info.sender.to_string(),
                 });
+            }
+            // check wl per address limit
+            let tokens: Cw721TokensResponse = deps.querier.query_wasm_smart(
+                sg721_address.to_string(),
+                &Sg721QueryMsg::Tokens {
+                    owner: info.sender.to_string(),
+                    start_after: None,
+                    limit: Some(wl_config.per_address_limit as u32),
+                },
+            )?;
+            if tokens.tokens.len() >= wl_config.per_address_limit as usize {
+                return Err(ContractError::MaxPerAddressLimitExceeded {});
             }
         } else {
             pub_mint = true;
@@ -567,14 +581,11 @@ pub fn mint_price(deps: Deps, admin_no_fee: bool) -> Result<Coin, StdError> {
             denom: NATIVE_DENOM.to_string(),
         }
     } else if let Some(whitelist) = config.whitelist {
-        let res_is_active: IsActiveResponse = deps
+        let wl_config: WhitelistConfigResponse = deps
             .querier
-            .query_wasm_smart(whitelist.clone(), &WhitelistQueryMsg::IsActive {})?;
-        if res_is_active.is_active {
-            let unit_price: UnitPriceResponse = deps
-                .querier
-                .query_wasm_smart(whitelist, &WhitelistQueryMsg::UnitPrice {})?;
-            unit_price.unit_price
+            .query_wasm_smart(whitelist.clone(), &WhitelistQueryMsg::Config {})?;
+        if wl_config.is_active {
+            wl_config.unit_price
         } else {
             config.unit_price.clone()
         }

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -567,6 +567,21 @@ fn whitelist_access_len_add_remove_expiration() {
     );
     assert!(res.is_ok());
 
+    // mint fails, over whitelist per address limit
+    let mint_msg = ExecuteMsg::Mint {};
+    let err = router
+        .execute_contract(
+            buyer.clone(),
+            minter_addr.clone(),
+            &mint_msg,
+            &coins(WHITELIST_AMOUNT, NATIVE_DENOM),
+        )
+        .unwrap_err();
+    assert_eq!(
+        err.source().unwrap().to_string(),
+        ContractError::MaxPerAddressLimitExceeded {}.to_string()
+    );
+
     // remove buyer from whitelist
     let inner_msg = UpdateMembersMsg {
         add: vec![],

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -25,7 +25,7 @@ const UNIT_PRICE: u128 = 100_000_000;
 const MINT_FEE: u128 = 10_000_000;
 const MAX_TOKEN_LIMIT: u32 = 10000;
 const WHITELIST_AMOUNT: u128 = 66_000_000;
-const WL_PER_ADDRESS_LIMIT: u64 = 1;
+const WL_PER_ADDRESS_LIMIT: u32 = 1;
 const ADMIN_MINT_PRICE: u128 = 0;
 
 fn custom_mock_app() -> StargazeApp {

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -25,6 +25,7 @@ const UNIT_PRICE: u128 = 100_000_000;
 const MINT_FEE: u128 = 10_000_000;
 const MAX_TOKEN_LIMIT: u32 = 10000;
 const WHITELIST_AMOUNT: u128 = 66_000_000;
+const WL_PER_ADDRESS_LIMIT: u64 = 1;
 const ADMIN_MINT_PRICE: u128 = 0;
 
 fn custom_mock_app() -> StargazeApp {
@@ -69,6 +70,7 @@ fn setup_whitelist_contract(
         start_time: Expiration::Never {},
         end_time: Expiration::Never {},
         unit_price: coin(WHITELIST_AMOUNT, NATIVE_DENOM),
+        per_address_limit: WL_PER_ADDRESS_LIMIT,
     };
     let whitelist_addr = router
         .instantiate_contract(

--- a/contracts/whitelist/schema/config.json
+++ b/contracts/whitelist/schema/config.json
@@ -24,7 +24,7 @@
     },
     "per_address_limit": {
       "type": "integer",
-      "format": "uint64",
+      "format": "uint32",
       "minimum": 0.0
     },
     "start_time": {

--- a/contracts/whitelist/schema/config.json
+++ b/contracts/whitelist/schema/config.json
@@ -6,6 +6,7 @@
     "admin",
     "end_time",
     "num_members",
+    "per_address_limit",
     "start_time",
     "unit_price"
   ],
@@ -19,6 +20,11 @@
     "num_members": {
       "type": "integer",
       "format": "uint32",
+      "minimum": 0.0
+    },
+    "per_address_limit": {
+      "type": "integer",
+      "format": "uint64",
       "minimum": 0.0
     },
     "start_time": {

--- a/contracts/whitelist/schema/execute_msg.json
+++ b/contracts/whitelist/schema/execute_msg.json
@@ -37,6 +37,20 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_per_address_limit"
+      ],
+      "properties": {
+        "update_per_address_limit": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/whitelist/schema/instantiate_msg.json
+++ b/contracts/whitelist/schema/instantiate_msg.json
@@ -5,6 +5,7 @@
   "required": [
     "end_time",
     "members",
+    "per_address_limit",
     "start_time",
     "unit_price"
   ],
@@ -17,6 +18,11 @@
       "items": {
         "type": "string"
       }
+    },
+    "per_address_limit": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     },
     "start_time": {
       "$ref": "#/definitions/Expiration"

--- a/contracts/whitelist/schema/instantiate_msg.json
+++ b/contracts/whitelist/schema/instantiate_msg.json
@@ -21,7 +21,7 @@
     },
     "per_address_limit": {
       "type": "integer",
-      "format": "uint64",
+      "format": "uint32",
       "minimum": 0.0
     },
     "start_time": {

--- a/contracts/whitelist/schema/query_msg.json
+++ b/contracts/whitelist/schema/query_msg.json
@@ -105,6 +105,18 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/whitelist/src/contract.rs
+++ b/contracts/whitelist/src/contract.rs
@@ -50,6 +50,12 @@ pub fn instantiate(
             got: msg.per_address_limit.to_string(),
         });
     }
+    if msg.per_address_limit == 0 {
+        return Err(ContractError::InvalidPerAddressLimit {
+            max: "must be > 0".to_string(),
+            got: msg.per_address_limit.to_string(),
+        });
+    }
 
     let config = Config {
         admin: info.sender.clone(),

--- a/contracts/whitelist/src/contract.rs
+++ b/contracts/whitelist/src/contract.rs
@@ -23,6 +23,7 @@ const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const MAX_MEMBERS: u32 = 5000;
 const CREATION_FEE: u128 = 100_000_000;
 const MIN_MINT_PRICE: u128 = 25_000_000;
+const MAX_PER_ADDRESS_LIMIT: u64 = 30;
 
 type Response = cosmwasm_std::Response<StargazeMsgWrapper>;
 
@@ -40,6 +41,14 @@ pub fn instantiate(
             msg.unit_price.amount.u128(),
             MIN_MINT_PRICE,
         ));
+    }
+
+    // Check per address limit is valid
+    if msg.per_address_limit > MAX_PER_ADDRESS_LIMIT {
+        return Err(ContractError::InvalidPerAddressLimit {
+            max: MAX_PER_ADDRESS_LIMIT.to_string(),
+            got: msg.per_address_limit.to_string(),
+        });
     }
 
     let config = Config {

--- a/contracts/whitelist/src/contract.rs
+++ b/contracts/whitelist/src/contract.rs
@@ -186,7 +186,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::IsActive {} => to_binary(&query_is_active(deps, env)?),
         QueryMsg::HasMember { member } => to_binary(&query_has_member(deps, member)?),
         QueryMsg::UnitPrice {} => to_binary(&query_unit_price(deps)?),
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        QueryMsg::Config {} => to_binary(&query_config(deps, env)?),
     }
 }
 
@@ -250,14 +250,19 @@ fn query_has_member(deps: Deps, member: String) -> StdResult<HasMemberResponse> 
     })
 }
 
-fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
-    let config = CONFIG.load(deps.storage)?;
+fn query_config(deps: Deps, env: Env) -> StdResult<ConfigResponse> {
+    let per_address_limit = CONFIG.load(deps.storage)?.per_address_limit;
+    let start_time = CONFIG.load(deps.storage)?.start_time;
+    let end_time = CONFIG.load(deps.storage)?.end_time;
+    let unit_price = CONFIG.load(deps.storage)?.unit_price;
+    let is_active: bool = query_is_active(deps, env)?.is_active;
 
     Ok(ConfigResponse {
-        per_address_limit: config.per_address_limit,
-        start_time: config.start_time,
-        end_time: config.end_time,
-        unit_price: config.unit_price,
+        per_address_limit,
+        start_time,
+        end_time,
+        unit_price,
+        is_active,
     })
 }
 

--- a/contracts/whitelist/src/contract.rs
+++ b/contracts/whitelist/src/contract.rs
@@ -23,7 +23,7 @@ const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const MAX_MEMBERS: u32 = 5000;
 const CREATION_FEE: u128 = 100_000_000;
 const MIN_MINT_PRICE: u128 = 25_000_000;
-const MAX_PER_ADDRESS_LIMIT: u64 = 30;
+const MAX_PER_ADDRESS_LIMIT: u32 = 30;
 
 type Response = cosmwasm_std::Response<StargazeMsgWrapper>;
 
@@ -191,7 +191,7 @@ pub fn execute_update_per_address_limit(
     deps: DepsMut,
     _env: Env,
     info: MessageInfo,
-    per_address_limit: u64,
+    per_address_limit: u32,
 ) -> Result<Response, ContractError> {
     let mut config = CONFIG.load(deps.storage)?;
     if info.sender != config.admin {
@@ -422,7 +422,7 @@ mod tests {
         let mut deps = mock_dependencies();
         setup_contract(deps.as_mut());
 
-        let per_address_limit: u64 = 50;
+        let per_address_limit: u32 = 50;
         let msg = ExecuteMsg::UpdatePerAddressLimit(per_address_limit);
         let info = mock_info(ADMIN, &[]);
         // let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -437,7 +437,7 @@ mod tests {
             err.to_string()
         );
 
-        let per_address_limit = 2;
+        let per_address_limit: u32 = 2;
         let msg = ExecuteMsg::UpdatePerAddressLimit(per_address_limit);
         let info = mock_info(ADMIN, &[]);
         let res = execute(deps.as_mut(), mock_env(), info, msg).unwrap();

--- a/contracts/whitelist/src/error.rs
+++ b/contracts/whitelist/src/error.rs
@@ -17,6 +17,9 @@ pub enum ContractError {
     #[error("MembersExceeded: {expected} got {actual}")]
     MembersExceeded { expected: u32, actual: u32 },
 
+    #[error("Invalid minting limit per address. max: {max}, got: {got}")]
+    InvalidPerAddressLimit { max: String, got: String },
+
     #[error("{0}")]
     Fee(#[from] FeeError),
 

--- a/contracts/whitelist/src/error.rs
+++ b/contracts/whitelist/src/error.rs
@@ -20,6 +20,9 @@ pub enum ContractError {
     #[error("Invalid minting limit per address. max: {max}, got: {got}")]
     InvalidPerAddressLimit { max: String, got: String },
 
+    #[error("Max minting limit per address exceeded")]
+    MaxPerAddressLimitExceeded {},
+
     #[error("{0}")]
     Fee(#[from] FeeError),
 

--- a/contracts/whitelist/src/msg.rs
+++ b/contracts/whitelist/src/msg.rs
@@ -18,6 +18,7 @@ pub enum ExecuteMsg {
     UpdateStartTime(Expiration),
     UpdateEndTime(Expiration),
     UpdateMembers(UpdateMembersMsg),
+    UpdatePerAddressLimit(u64),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/whitelist/src/msg.rs
+++ b/contracts/whitelist/src/msg.rs
@@ -81,4 +81,5 @@ pub struct ConfigResponse {
     pub start_time: Expiration,
     pub end_time: Expiration,
     pub unit_price: Coin,
+    pub is_active: bool,
 }

--- a/contracts/whitelist/src/msg.rs
+++ b/contracts/whitelist/src/msg.rs
@@ -9,6 +9,7 @@ pub struct InstantiateMsg {
     pub start_time: Expiration,
     pub end_time: Expiration,
     pub unit_price: Coin,
+    pub per_address_limit: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -36,6 +37,7 @@ pub enum QueryMsg {
     Members {},
     HasMember { member: String },
     UnitPrice {},
+    Config {},
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -70,5 +72,13 @@ pub struct IsActiveResponse {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct UnitPriceResponse {
+    pub unit_price: Coin,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigResponse {
+    pub per_address_limit: u64,
+    pub start_time: Expiration,
+    pub end_time: Expiration,
     pub unit_price: Coin,
 }

--- a/contracts/whitelist/src/msg.rs
+++ b/contracts/whitelist/src/msg.rs
@@ -9,7 +9,7 @@ pub struct InstantiateMsg {
     pub start_time: Expiration,
     pub end_time: Expiration,
     pub unit_price: Coin,
-    pub per_address_limit: u64,
+    pub per_address_limit: u32,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -18,7 +18,7 @@ pub enum ExecuteMsg {
     UpdateStartTime(Expiration),
     UpdateEndTime(Expiration),
     UpdateMembers(UpdateMembersMsg),
-    UpdatePerAddressLimit(u64),
+    UpdatePerAddressLimit(u32),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -78,7 +78,7 @@ pub struct UnitPriceResponse {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ConfigResponse {
-    pub per_address_limit: u64,
+    pub per_address_limit: u32,
     pub start_time: Expiration,
     pub end_time: Expiration,
     pub unit_price: Coin,

--- a/contracts/whitelist/src/state.rs
+++ b/contracts/whitelist/src/state.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub end_time: Expiration,
     pub num_members: u32,
     pub unit_price: Coin,
+    pub per_address_limit: u64,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/contracts/whitelist/src/state.rs
+++ b/contracts/whitelist/src/state.rs
@@ -11,7 +11,7 @@ pub struct Config {
     pub end_time: Expiration,
     pub num_members: u32,
     pub unit_price: Coin,
-    pub per_address_limit: u64,
+    pub per_address_limit: u32,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");


### PR DESCRIPTION
fix #79

whitelist has `per_address_limit` for minting. this allows creators to have a portion to whitelist community, and a portion to public mint