### PR TITLE
Better collection-level metadata

### DIFF
--- a/contracts/minter/schema/instantiate_msg.json
+++ b/contracts/minter/schema/instantiate_msg.json
@@ -74,24 +74,20 @@
         }
       }
     },
-    "Config": {
+    "CollectionInfo": {
       "type": "object",
+      "required": [
+        "image"
+      ],
       "properties": {
-        "contract_uri": {
+        "external_link": {
           "type": [
             "string",
             "null"
           ]
         },
-        "creator": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Addr"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "image": {
+          "type": "string"
         },
         "royalties": {
           "anyOf": [
@@ -158,20 +154,14 @@
     "InstantiateMsg": {
       "type": "object",
       "required": [
+        "collection_info",
         "minter",
         "name",
         "symbol"
       ],
       "properties": {
-        "config": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Config"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "collection_info": {
+          "$ref": "#/definitions/CollectionInfo"
         },
         "minter": {
           "type": "string"

--- a/contracts/minter/schema/instantiate_msg.json
+++ b/contracts/minter/schema/instantiate_msg.json
@@ -77,9 +77,13 @@
     "CollectionInfo": {
       "type": "object",
       "required": [
+        "description",
         "image"
       ],
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "external_link": {
           "type": [
             "string",

--- a/contracts/minter/src/contract.rs
+++ b/contracts/minter/src/contract.rs
@@ -128,7 +128,7 @@ pub fn instantiate(
                 name: msg.sg721_instantiate_msg.name,
                 symbol: msg.sg721_instantiate_msg.symbol,
                 minter: env.contract.address.to_string(),
-                config: msg.sg721_instantiate_msg.config,
+                collection_info: msg.sg721_instantiate_msg.collection_info,
             })?,
             funds: info.funds,
             admin: Some(info.sender.to_string()),

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -111,6 +111,7 @@ fn setup_minter_contract(
             symbol: String::from("TEST"),
             minter: creator.to_string(),
             collection_info: CollectionInfo {
+                description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
@@ -219,6 +220,7 @@ fn initialization() {
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
             collection_info: CollectionInfo {
+                description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
@@ -247,6 +249,7 @@ fn initialization() {
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
             collection_info: CollectionInfo {
+                description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
@@ -274,6 +277,7 @@ fn initialization() {
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
             collection_info: CollectionInfo {
+                description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
@@ -301,6 +305,7 @@ fn initialization() {
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
             collection_info: CollectionInfo {
+                description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
@@ -860,6 +865,7 @@ fn test_start_time_before_genesis() {
             symbol: String::from("TEST"),
             minter: creator.to_string(),
             collection_info: CollectionInfo {
+                description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -110,7 +110,7 @@ fn setup_minter_contract(
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: creator.to_string(),
-            config: Some(CollectionInfo {
+            collection_info: Some(CollectionInfo {
                 contract_uri: Some(String::from("ipfs://url.json")),
                 creator: Some(creator.clone()),
                 royalties: Some(RoyaltyInfo {
@@ -218,7 +218,7 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            config: Some(CollectionInfo {
+            collection_info: Some(CollectionInfo {
                 contract_uri: Some(String::from("test")),
                 creator: Some(info.sender.clone()),
                 royalties: Some(RoyaltyInfo {
@@ -246,7 +246,7 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            config: Some(CollectionInfo {
+            collection_info: Some(CollectionInfo {
                 contract_uri: Some(String::from("test")),
                 creator: Some(info.sender.clone()),
                 royalties: Some(RoyaltyInfo {
@@ -273,7 +273,7 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            config: Some(CollectionInfo {
+            collection_info: Some(CollectionInfo {
                 contract_uri: Some(String::from("test")),
                 creator: Some(info.sender.clone()),
                 royalties: Some(RoyaltyInfo {
@@ -300,7 +300,7 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            config: Some(CollectionInfo {
+            collection_info: Some(CollectionInfo {
                 contract_uri: Some(String::from("test")),
                 creator: Some(info.sender.clone()),
                 royalties: Some(RoyaltyInfo {
@@ -859,7 +859,7 @@ fn test_start_time_before_genesis() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: creator.to_string(),
-            config: Some(CollectionInfo {
+            collection_info: Some(CollectionInfo {
                 contract_uri: Some(String::from("ipfs://url.json")),
                 creator: Some(creator.clone()),
                 royalties: Some(RoyaltyInfo {

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -6,7 +6,7 @@ use cw721::{Cw721QueryMsg, OwnerOfResponse};
 use cw_multi_test::{BankSudo, Contract, ContractWrapper, Executor, SudoMsg};
 use cw_utils::Expiration;
 use sg721::msg::InstantiateMsg as Sg721InstantiateMsg;
-use sg721::state::{Config, RoyaltyInfo};
+use sg721::state::{CollectionInfo, RoyaltyInfo};
 use sg_std::{StargazeMsgWrapper, GENESIS_MINT_START_TIME, NATIVE_DENOM};
 use whitelist::msg::InstantiateMsg as WhitelistInstantiateMsg;
 use whitelist::msg::{ExecuteMsg as WhitelistExecuteMsg, UpdateMembersMsg};
@@ -110,7 +110,7 @@ fn setup_minter_contract(
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: creator.to_string(),
-            config: Some(Config {
+            config: Some(CollectionInfo {
                 contract_uri: Some(String::from("ipfs://url.json")),
                 creator: Some(creator.clone()),
                 royalties: Some(RoyaltyInfo {
@@ -218,7 +218,7 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            config: Some(Config {
+            config: Some(CollectionInfo {
                 contract_uri: Some(String::from("test")),
                 creator: Some(info.sender.clone()),
                 royalties: Some(RoyaltyInfo {
@@ -246,7 +246,7 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            config: Some(Config {
+            config: Some(CollectionInfo {
                 contract_uri: Some(String::from("test")),
                 creator: Some(info.sender.clone()),
                 royalties: Some(RoyaltyInfo {
@@ -273,7 +273,7 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            config: Some(Config {
+            config: Some(CollectionInfo {
                 contract_uri: Some(String::from("test")),
                 creator: Some(info.sender.clone()),
                 royalties: Some(RoyaltyInfo {
@@ -300,7 +300,7 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            config: Some(Config {
+            config: Some(CollectionInfo {
                 contract_uri: Some(String::from("test")),
                 creator: Some(info.sender.clone()),
                 royalties: Some(RoyaltyInfo {
@@ -859,7 +859,7 @@ fn test_start_time_before_genesis() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: creator.to_string(),
-            config: Some(Config {
+            config: Some(CollectionInfo {
                 contract_uri: Some(String::from("ipfs://url.json")),
                 creator: Some(creator.clone()),
                 royalties: Some(RoyaltyInfo {

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -110,14 +110,14 @@ fn setup_minter_contract(
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: creator.to_string(),
-            collection_info: Some(CollectionInfo {
-                contract_uri: Some(String::from("ipfs://url.json")),
-                creator: Some(creator.clone()),
+            collection_info: CollectionInfo {
+                image: "https://example.com/image.png".to_string(),
+                external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
                     payment_address: creator.clone(),
                     share: Decimal::percent(10),
                 }),
-            }),
+            },
         },
     };
     let minter_addr = router
@@ -218,14 +218,14 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            collection_info: Some(CollectionInfo {
-                contract_uri: Some(String::from("test")),
-                creator: Some(info.sender.clone()),
+            collection_info: CollectionInfo {
+                image: "https://example.com/image.png".to_string(),
+                external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
                     payment_address: info.sender.clone(),
                     share: Decimal::percent(10),
                 }),
-            }),
+            },
         },
     };
     let res = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -246,14 +246,14 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            collection_info: Some(CollectionInfo {
-                contract_uri: Some(String::from("test")),
-                creator: Some(info.sender.clone()),
+            collection_info: CollectionInfo {
+                image: "https://example.com/image.png".to_string(),
+                external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
                     payment_address: info.sender.clone(),
                     share: Decimal::percent(10),
                 }),
-            }),
+            },
         },
     };
     let res = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -273,14 +273,14 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            collection_info: Some(CollectionInfo {
-                contract_uri: Some(String::from("test")),
-                creator: Some(info.sender.clone()),
+            collection_info: CollectionInfo {
+                image: "https://example.com/image.png".to_string(),
+                external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
                     payment_address: info.sender.clone(),
                     share: Decimal::percent(10),
                 }),
-            }),
+            },
         },
     };
     let res = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -300,14 +300,14 @@ fn initialization() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: info.sender.to_string(),
-            collection_info: Some(CollectionInfo {
-                contract_uri: Some(String::from("test")),
-                creator: Some(info.sender.clone()),
+            collection_info: CollectionInfo {
+                image: "https://example.com/image.png".to_string(),
+                external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
                     payment_address: info.sender.clone(),
                     share: Decimal::percent(10),
                 }),
-            }),
+            },
         },
     };
     let res = instantiate(deps.as_mut(), mock_env(), info, msg);
@@ -859,14 +859,14 @@ fn test_start_time_before_genesis() {
             name: String::from("TEST"),
             symbol: String::from("TEST"),
             minter: creator.to_string(),
-            collection_info: Some(CollectionInfo {
-                contract_uri: Some(String::from("ipfs://url.json")),
-                creator: Some(creator.clone()),
+            collection_info: CollectionInfo {
+                image: "https://example.com/image.png".to_string(),
+                external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
                     payment_address: creator.clone(),
                     share: Decimal::percent(10),
                 }),
-            }),
+            },
         },
     };
     let minter_addr = router

--- a/contracts/sg721/schema/instantiate_msg.json
+++ b/contracts/sg721/schema/instantiate_msg.json
@@ -30,9 +30,13 @@
     "CollectionInfo": {
       "type": "object",
       "required": [
+        "description",
         "image"
       ],
       "properties": {
+        "description": {
+          "type": "string"
+        },
         "external_link": {
           "type": [
             "string",

--- a/contracts/sg721/schema/instantiate_msg.json
+++ b/contracts/sg721/schema/instantiate_msg.json
@@ -3,20 +3,14 @@
   "title": "InstantiateMsg",
   "type": "object",
   "required": [
+    "collection_info",
     "minter",
     "name",
     "symbol"
   ],
   "properties": {
-    "config": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Config"
-        },
-        {
-          "type": "null"
-        }
-      ]
+    "collection_info": {
+      "$ref": "#/definitions/CollectionInfo"
     },
     "minter": {
       "type": "string"
@@ -33,24 +27,20 @@
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
       "type": "string"
     },
-    "Config": {
+    "CollectionInfo": {
       "type": "object",
+      "required": [
+        "image"
+      ],
       "properties": {
-        "contract_uri": {
+        "external_link": {
           "type": [
             "string",
             "null"
           ]
         },
-        "creator": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Addr"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "image": {
+          "type": "string"
         },
         "royalties": {
           "anyOf": [

--- a/contracts/sg721/schema/query_msg.json
+++ b/contracts/sg721/schema/query_msg.json
@@ -271,46 +271,10 @@
     {
       "type": "object",
       "required": [
-        "contract_uri"
+        "collection_info"
       ],
       "properties": {
-        "contract_uri": {
-          "type": "object"
-        }
-      },
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "required": [
-        "creator"
-      ],
-      "properties": {
-        "creator": {
-          "type": "object"
-        }
-      },
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "required": [
-        "royalties"
-      ],
-      "properties": {
-        "royalties": {
-          "type": "object"
-        }
-      },
-      "additionalProperties": false
-    },
-    {
-      "type": "object",
-      "required": [
-        "config"
-      ],
-      "properties": {
-        "config": {
+        "collection_info": {
           "type": "object"
         }
       },

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -56,6 +56,10 @@ pub fn instantiate(
         .save(deps.storage, &minter)?;
 
     // sg721 instantiation
+    if msg.collection_info.description.len() > 256 {
+        return Err(ContractError::DescriptionTooLong {});
+    }
+
     let image = Url::parse(&msg.collection_info.image)?;
 
     if let Some(ref external_link) = msg.collection_info.external_link {
@@ -98,6 +102,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 fn query_config(deps: Deps) -> StdResult<CollectionInfoResponse> {
     let info = CONFIG.load(deps.storage)?;
     Ok(CollectionInfoResponse {
+        description: info.description,
         image: info.image,
         external_link: info.external_link,
         royalty: info.royalties,
@@ -124,6 +129,7 @@ mod tests {
             symbol: String::from("BOBO"),
             minter: String::from("minter"),
             collection_info: CollectionInfo {
+                description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
                 royalties: None,
@@ -139,6 +145,7 @@ mod tests {
         let res = query(deps.as_ref(), mock_env(), QueryMsg::CollectionInfo {}).unwrap();
         let value: CollectionInfoResponse = from_binary(&res).unwrap();
         assert_eq!("https://example.com/image.png", value.image);
+        assert_eq!("Stargaze Monkeys", value.description);
         assert_eq!(
             "https://example.com/external.html",
             value.external_link.unwrap()
@@ -157,6 +164,7 @@ mod tests {
             symbol: String::from("BOBO"),
             minter: String::from("minter"),
             collection_info: CollectionInfo {
+                description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -12,7 +12,7 @@ use cw721::ContractInfoResponse;
 use cw721_base::ContractError as BaseError;
 use url::Url;
 
-use crate::msg::{ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::msg::{CollectionInfoResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state::CONFIG;
 
 // version info for migration info
@@ -49,13 +49,14 @@ pub fn instantiate(
     Sg721Contract::default()
         .contract_info
         .save(deps.storage, &info)?;
+
     let minter = deps.api.addr_validate(&msg.minter)?;
     Sg721Contract::default()
         .minter
         .save(deps.storage, &minter)?;
 
     // sg721 instantiation
-    let image_url = Url::parse(&msg.collection_info.image)?;
+    let image = Url::parse(&msg.collection_info.image)?;
 
     if let Some(ref external_link) = msg.collection_info.external_link {
         Url::parse(external_link)?;
@@ -72,6 +73,7 @@ pub fn instantiate(
         .add_attribute("action", "instantiate")
         .add_attribute("contract_name", CONTRACT_NAME)
         .add_attribute("contract_version", CONTRACT_VERSION)
+        .add_attribute("image", image.to_string())
         .add_messages(fee_msgs))
 }
 
@@ -88,19 +90,17 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Config {} => to_binary(&query_config(deps)?),
+        QueryMsg::CollectionInfo {} => to_binary(&query_config(deps)?),
         _ => Sg721Contract::default().query(deps, env, msg.into()),
     }
 }
 
-fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
-    let contract_uri = CONFIG.load(deps.storage)?.contract_uri;
-    let creator = CONFIG.load(deps.storage)?.creator;
-    let royalty = CONFIG.load(deps.storage)?.royalties;
-    Ok(ConfigResponse {
-        contract_uri,
-        creator,
-        royalty,
+fn query_config(deps: Deps) -> StdResult<CollectionInfoResponse> {
+    let info = CONFIG.load(deps.storage)?;
+    Ok(CollectionInfoResponse {
+        image: info.image,
+        external_link: info.external_link,
+        royalty: info.royalties,
     })
 }
 
@@ -117,18 +117,17 @@ mod tests {
     #[test]
     fn proper_initialization_no_royalties() {
         let mut deps = mock_dependencies();
-        let creator = String::from("creator");
         let collection = String::from("collection0");
 
         let msg = InstantiateMsg {
             name: collection,
             symbol: String::from("BOBO"),
             minter: String::from("minter"),
-            collection_info: Some(CollectionInfo {
-                contract_uri: Some(String::from("ipfs://bafyreibvxty5gjyeedk7or7tahyrzgbrwjkolpairjap3bmegvcjdipt74.ipfs.dweb.link/metadata.json")),
-                creator: Some(Addr::unchecked(creator)),
+            collection_info: CollectionInfo {
+                image: "https://example.com/image.png".to_string(),
+                external_link: Some("https://example.com/external.html".to_string()),
                 royalties: None,
-            }),
+            },
         };
         let info = mock_info("creator", &coins(CREATION_FEE, NATIVE_DENOM));
 
@@ -136,20 +135,14 @@ mod tests {
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(2, res.messages.len());
 
-        // it worked, let's query the contract_uri
-        let res = query(deps.as_ref(), mock_env(), QueryMsg::ContractUri {}).unwrap();
-        let value: ContractUriResponse = from_binary(&res).unwrap();
-        assert_eq!(Some("ipfs://bafyreibvxty5gjyeedk7or7tahyrzgbrwjkolpairjap3bmegvcjdipt74.ipfs.dweb.link/metadata.json".to_string()), value.contract_uri);
-
-        // it worked, let's query the creator
-        let res = query(deps.as_ref(), mock_env(), QueryMsg::Creator {}).unwrap();
-
-        let value: CreatorResponse = from_binary(&res).unwrap();
-        assert_eq!("creator", value.creator.unwrap().to_string());
-
-        // let's query the royalties
-        let res = query(deps.as_ref(), mock_env(), QueryMsg::Royalties {}).unwrap();
-        let value: RoyaltyResponse = from_binary(&res).unwrap();
+        // let's query the collection info
+        let res = query(deps.as_ref(), mock_env(), QueryMsg::CollectionInfo {}).unwrap();
+        let value: CollectionInfoResponse = from_binary(&res).unwrap();
+        assert_eq!("https://example.com/image.png", value.image);
+        assert_eq!(
+            "https://example.com/external.html",
+            value.external_link.unwrap()
+        );
         assert_eq!(None, value.royalty);
     }
 
@@ -163,14 +156,14 @@ mod tests {
             name: collection,
             symbol: String::from("BOBO"),
             minter: String::from("minter"),
-            collection_info: Some(CollectionInfo {
-                contract_uri: Some(String::from("ipfs://bafyreibvxty5gjyeedk7or7tahyrzgbrwjkolpairjap3bmegvcjdipt74.ipfs.dweb.link/metadata.json")),
-                creator: Some(Addr::unchecked(creator.clone())),
+            collection_info: CollectionInfo {
+                image: "https://example.com/image.png".to_string(),
+                external_link: Some("https://example.com/external.html".to_string()),
                 royalties: Some(RoyaltyInfo {
                     payment_address: Addr::unchecked(creator.clone()),
                     share: Decimal::percent(10),
                 }),
-            }),
+            },
         };
         let info = mock_info("creator", &coins(CREATION_FEE, NATIVE_DENOM));
 
@@ -178,35 +171,15 @@ mod tests {
         let res = instantiate(deps.as_mut(), mock_env(), info, msg).unwrap();
         assert_eq!(2, res.messages.len());
 
-        // it worked, let's query the contract_uri
-        let res = query(deps.as_ref(), mock_env(), QueryMsg::ContractUri {}).unwrap();
-        let value: ContractUriResponse = from_binary(&res).unwrap();
-        assert_eq!(Some("ipfs://bafyreibvxty5gjyeedk7or7tahyrzgbrwjkolpairjap3bmegvcjdipt74.ipfs.dweb.link/metadata.json".to_string()), value.contract_uri);
-
-        // it worked, let's query the creator
-        let res = query(deps.as_ref(), mock_env(), QueryMsg::Creator {}).unwrap();
-
-        let value: CreatorResponse = from_binary(&res).unwrap();
-        assert_eq!("creator", value.creator.unwrap().to_string());
-
-        // let's query the royalties
-        let res = query(deps.as_ref(), mock_env(), QueryMsg::Royalties {}).unwrap();
-        let value: RoyaltyResponse = from_binary(&res).unwrap();
+        // let's query the collection info
+        let res = query(deps.as_ref(), mock_env(), QueryMsg::CollectionInfo {}).unwrap();
+        let value: CollectionInfoResponse = from_binary(&res).unwrap();
         assert_eq!(
             Some(RoyaltyInfo {
                 payment_address: Addr::unchecked(creator),
                 share: Decimal::percent(10),
             }),
             value.royalty
-        );
-
-        let res = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
-        let value: ConfigResponse = from_binary(&res).unwrap();
-        assert_eq!("ipfs://bafyreibvxty5gjyeedk7or7tahyrzgbrwjkolpairjap3bmegvcjdipt74.ipfs.dweb.link/metadata.json".to_string(), value.contract_uri.unwrap());
-        assert_eq!("creator", value.creator.unwrap().to_string());
-        assert_eq!(
-            "creator",
-            value.royalty.unwrap().payment_address.to_string()
         );
     }
 }

--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -12,10 +12,7 @@ use cw721::ContractInfoResponse;
 use cw721_base::ContractError as BaseError;
 use url::Url;
 
-use crate::msg::{
-    ConfigResponse, ContractUriResponse, CreatorResponse, ExecuteMsg, InstantiateMsg, QueryMsg,
-    RoyaltyResponse,
-};
+use crate::msg::{ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::state::CONFIG;
 
 // version info for migration info
@@ -92,27 +89,9 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::ContractUri {} => to_binary(&query_contract_uri(deps)?),
-        QueryMsg::Creator {} => to_binary(&query_creator(deps)?),
-        QueryMsg::Royalties {} => to_binary(&query_royalties(deps)?),
         QueryMsg::Config {} => to_binary(&query_config(deps)?),
         _ => Sg721Contract::default().query(deps, env, msg.into()),
     }
-}
-
-fn query_contract_uri(deps: Deps) -> StdResult<ContractUriResponse> {
-    let contract_uri = CONFIG.load(deps.storage)?.contract_uri;
-    Ok(ContractUriResponse { contract_uri })
-}
-
-fn query_creator(deps: Deps) -> StdResult<CreatorResponse> {
-    let creator = CONFIG.load(deps.storage)?.creator;
-    Ok(CreatorResponse { creator })
-}
-
-fn query_royalties(deps: Deps) -> StdResult<RoyaltyResponse> {
-    let royalty = CONFIG.load(deps.storage)?.royalties;
-    Ok(RoyaltyResponse { royalty })
 }
 
 fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
@@ -130,7 +109,7 @@ fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
 mod tests {
     use super::*;
 
-    use crate::state::Config;
+    use crate::state::CollectionInfo;
     use crate::state::RoyaltyInfo;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use cosmwasm_std::{coins, from_binary, Addr, Decimal};
@@ -146,7 +125,7 @@ mod tests {
             name: collection,
             symbol: String::from("BOBO"),
             minter: String::from("minter"),
-            config: Some(Config {
+            config: Some(CollectionInfo {
                 contract_uri: Some(String::from("ipfs://bafyreibvxty5gjyeedk7or7tahyrzgbrwjkolpairjap3bmegvcjdipt74.ipfs.dweb.link/metadata.json")),
                 creator: Some(Addr::unchecked(creator)),
                 royalties: None,
@@ -185,7 +164,7 @@ mod tests {
             name: collection,
             symbol: String::from("BOBO"),
             minter: String::from("minter"),
-            config: Some(Config {
+            config: Some(CollectionInfo {
                 contract_uri: Some(String::from("ipfs://bafyreibvxty5gjyeedk7or7tahyrzgbrwjkolpairjap3bmegvcjdipt74.ipfs.dweb.link/metadata.json")),
                 creator: Some(Addr::unchecked(creator.clone())),
                 royalties: Some(RoyaltyInfo {

--- a/contracts/sg721/src/error.rs
+++ b/contracts/sg721/src/error.rs
@@ -1,3 +1,5 @@
+use std::string::ParseError;
+
 use cosmwasm_std::StdError;
 use cw721_base::ContractError as Cw721ContractError;
 use cw_utils::PaymentError;
@@ -30,11 +32,14 @@ pub enum ContractError {
     #[error("{0}")]
     Payment(#[from] PaymentError),
 
-    #[error("InvalidContractUri")]
-    InvalidContractUri {},
-
     #[error("{0}")]
     Fee(#[from] FeeError),
+
+    #[error("InvalidImageUrl")]
+    InvalidImageUrl {},
+
+    #[error("{0}")]
+    Parse(#[from] ParseError),
 }
 
 impl From<ContractError> for Cw721ContractError {
@@ -45,5 +50,11 @@ impl From<ContractError> for Cw721ContractError {
             ContractError::Expired {} => Cw721ContractError::Expired {},
             _ => unreachable!("cannot convert {:?} to Cw721ContractError", err),
         }
+    }
+}
+
+impl From<ParseError> for ContractError {
+    fn from(err: ParseError) -> ContractError {
+        ContractError::InvalidImageUrl {}
     }
 }

--- a/contracts/sg721/src/error.rs
+++ b/contracts/sg721/src/error.rs
@@ -28,6 +28,9 @@ pub enum ContractError {
     #[error("Invalid Royalities")]
     InvalidRoyalities {},
 
+    #[error("Description too long")]
+    DescriptionTooLong {},
+
     #[error("{0}")]
     Payment(#[from] PaymentError),
 

--- a/contracts/sg721/src/error.rs
+++ b/contracts/sg721/src/error.rs
@@ -1,10 +1,9 @@
-use std::string::ParseError;
-
 use cosmwasm_std::StdError;
 use cw721_base::ContractError as Cw721ContractError;
 use cw_utils::PaymentError;
 use sg_std::fees::FeeError;
 use thiserror::Error;
+use url::ParseError;
 
 #[derive(Error, Debug)]
 pub enum ContractError {
@@ -35,9 +34,6 @@ pub enum ContractError {
     #[error("{0}")]
     Fee(#[from] FeeError),
 
-    #[error("InvalidImageUrl")]
-    InvalidImageUrl {},
-
     #[error("{0}")]
     Parse(#[from] ParseError),
 }
@@ -50,11 +46,5 @@ impl From<ContractError> for Cw721ContractError {
             ContractError::Expired {} => Cw721ContractError::Expired {},
             _ => unreachable!("cannot convert {:?} to Cw721ContractError", err),
         }
-    }
-}
-
-impl From<ParseError> for ContractError {
-    fn from(err: ParseError) -> ContractError {
-        ContractError::InvalidImageUrl {}
     }
 }

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -125,6 +125,7 @@ impl From<QueryMsg> for Cw721QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CollectionInfoResponse {
+    pub description: String,
     pub image: String,
     pub external_link: Option<String>,
     pub royalty: Option<RoyaltyInfo>,

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -55,7 +55,7 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
     Minter {},
-    Config {},
+    CollectionInfo {},
 }
 
 impl From<QueryMsg> for Cw721QueryMsg {
@@ -124,7 +124,7 @@ impl From<QueryMsg> for Cw721QueryMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ConfigResponse {
+pub struct CollectionInfoResponse {
     pub image: String,
     pub external_link: Option<String>,
     pub royalty: Option<RoyaltyInfo>,

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -9,7 +9,7 @@ pub struct InstantiateMsg {
     pub name: String,
     pub symbol: String,
     pub minter: String,
-    pub config: Option<CollectionInfo>,
+    pub collection_info: CollectionInfo,
 }
 
 pub type ExecuteMsg = cw721_base::ExecuteMsg<Empty>;

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -1,5 +1,5 @@
-use crate::state::{Config, RoyaltyInfo};
-use cosmwasm_std::{Addr, Empty};
+use crate::state::{CollectionInfo, RoyaltyInfo};
+use cosmwasm_std::Empty;
 use cw721_base::msg::QueryMsg as Cw721QueryMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -9,7 +9,7 @@ pub struct InstantiateMsg {
     pub name: String,
     pub symbol: String,
     pub minter: String,
-    pub config: Option<Config>,
+    pub config: Option<CollectionInfo>,
 }
 
 pub type ExecuteMsg = cw721_base::ExecuteMsg<Empty>;
@@ -55,9 +55,6 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
     Minter {},
-    ContractUri {},
-    Creator {},
-    Royalties {},
     Config {},
 }
 
@@ -127,23 +124,8 @@ impl From<QueryMsg> for Cw721QueryMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct ContractUriResponse {
-    pub contract_uri: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct CreatorResponse {
-    pub creator: Option<Addr>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct RoyaltyResponse {
-    pub royalty: Option<RoyaltyInfo>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ConfigResponse {
-    pub contract_uri: Option<String>,
-    pub creator: Option<Addr>,
+    pub image: String,
+    pub external_link: Option<String>,
     pub royalty: Option<RoyaltyInfo>,
 }

--- a/contracts/sg721/src/state.rs
+++ b/contracts/sg721/src/state.rs
@@ -5,9 +5,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct Config {
-    pub contract_uri: Option<String>,
-    pub creator: Option<Addr>,
+pub struct CollectionInfo {
+    pub image: String,
+    pub external_link: Option<String>,
     pub royalties: Option<RoyaltyInfo>,
 }
 
@@ -32,4 +32,4 @@ impl RoyaltyInfo {
     }
 }
 
-pub const CONFIG: Item<Config> = Item::new("config");
+pub const CONFIG: Item<CollectionInfo> = Item::new("config");

--- a/contracts/sg721/src/state.rs
+++ b/contracts/sg721/src/state.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CollectionInfo {
+    pub description: String,
     pub image: String,
     pub external_link: Option<String>,
     pub royalties: Option<RoyaltyInfo>,


### PR DESCRIPTION
Been having lots of confusion with creators and testers using the tooling about the redundant data in cw721 collection info and contract URI. This is an attempt to clear things up and and have a single source of truth for collection data. It basically moves everything we need from contract URI into sg721.

This introduces two required fields, `image` that serves as a preview image for the entire collection, and `description`. `image` doesn't need to be an IPFS link since it's more marketplace-level metadata and is not a traded asset like the individual NFTs. Note this does not break compatibility with cw721 since instantiation is not part of the cw721 spec.

This also introduces an optional `external_link` that can be a website, etc. 

These two fields are all we needed from contract URI anyway. The name, description, seller_fee (royalties) were redundant because they're already part of cw721 `ContractInfo` and sg721 royalties. Contract URI is used on OpenSea mainly due to a limitation of ERC721 that doesn't include basic metadata like name and description.

Also removed `creator` since it's already part of `ContractInfoResponse`, and `payment_address` is already part of royalties.

I think this cleans and simplifies a lot, and makes collection info more explicitly defined. Also it's one less thing for creators to worry about and less error prone. Also collection info should be easily queried and can easily live on-chain. No need to hide behind an IPFS link. It's also not part of ICS-721 so there's no benefit in interoperability either.