### PR TITLE
Idiomatic royalty validation

### DIFF
--- a/contracts/minter/schema/instantiate_msg.json
+++ b/contracts/minter/schema/instantiate_msg.json
@@ -47,10 +47,6 @@
     }
   },
   "definitions": {
-    "Addr": {
-      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-      "type": "string"
-    },
     "Coin": {
       "type": "object",
       "required": [
@@ -66,7 +62,7 @@
         }
       }
     },
-    "CollectionInfo": {
+    "CollectionInfo_for_RoyaltyInfoResponse": {
       "type": "object",
       "required": [
         "description",
@@ -85,10 +81,10 @@
         "image": {
           "type": "string"
         },
-        "royalties": {
+        "royalty_info": {
           "anyOf": [
             {
-              "$ref": "#/definitions/RoyaltyInfo"
+              "$ref": "#/definitions/RoyaltyInfoResponse"
             },
             {
               "type": "null"
@@ -157,7 +153,7 @@
       ],
       "properties": {
         "collection_info": {
-          "$ref": "#/definitions/CollectionInfo"
+          "$ref": "#/definitions/CollectionInfo_for_RoyaltyInfoResponse"
         },
         "minter": {
           "type": "string"
@@ -170,7 +166,7 @@
         }
       }
     },
-    "RoyaltyInfo": {
+    "RoyaltyInfoResponse": {
       "type": "object",
       "required": [
         "payment_address",
@@ -178,7 +174,7 @@
       ],
       "properties": {
         "payment_address": {
-          "$ref": "#/definitions/Addr"
+          "type": "string"
         },
         "share": {
           "$ref": "#/definitions/Decimal"

--- a/contracts/minter/src/contract_tests.rs
+++ b/contracts/minter/src/contract_tests.rs
@@ -6,8 +6,8 @@ use cw721::{Cw721QueryMsg, OwnerOfResponse};
 use cw721_base::ExecuteMsg as Cw721ExecuteMsg;
 use cw_multi_test::{BankSudo, Contract, ContractWrapper, Executor, SudoMsg};
 use cw_utils::Expiration;
-use sg721::msg::InstantiateMsg as Sg721InstantiateMsg;
-use sg721::state::{CollectionInfo, RoyaltyInfo};
+use sg721::msg::{InstantiateMsg as Sg721InstantiateMsg, RoyaltyInfoResponse};
+use sg721::state::CollectionInfo;
 use sg_std::{StargazeMsgWrapper, GENESIS_MINT_START_TIME, NATIVE_DENOM};
 use whitelist::msg::InstantiateMsg as WhitelistInstantiateMsg;
 use whitelist::msg::{ExecuteMsg as WhitelistExecuteMsg, UpdateMembersMsg};
@@ -110,8 +110,8 @@ fn setup_minter_contract(
                 description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
-                royalties: Some(RoyaltyInfo {
-                    payment_address: creator.clone(),
+                royalty_info: Some(RoyaltyInfoResponse {
+                    payment_address: creator.to_string(),
                     share: Decimal::percent(10),
                 }),
             },
@@ -218,8 +218,8 @@ fn initialization() {
                 description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
-                royalties: Some(RoyaltyInfo {
-                    payment_address: info.sender.clone(),
+                royalty_info: Some(RoyaltyInfoResponse {
+                    payment_address: info.sender.to_string(),
                     share: Decimal::percent(10),
                 }),
             },
@@ -247,8 +247,8 @@ fn initialization() {
                 description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
-                royalties: Some(RoyaltyInfo {
-                    payment_address: info.sender.clone(),
+                royalty_info: Some(RoyaltyInfoResponse {
+                    payment_address: info.sender.to_string(),
                     share: Decimal::percent(10),
                 }),
             },
@@ -276,8 +276,8 @@ fn initialization() {
                 description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
-                royalties: Some(RoyaltyInfo {
-                    payment_address: info.sender.clone(),
+                royalty_info: Some(RoyaltyInfoResponse {
+                    payment_address: info.sender.to_string(),
                     share: Decimal::percent(10),
                 }),
             },
@@ -304,8 +304,8 @@ fn initialization() {
                 description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
-                royalties: Some(RoyaltyInfo {
-                    payment_address: info.sender.clone(),
+                royalty_info: Some(RoyaltyInfoResponse {
+                    payment_address: info.sender.to_string(),
                     share: Decimal::percent(10),
                 }),
             },
@@ -332,8 +332,8 @@ fn initialization() {
                 description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
-                royalties: Some(RoyaltyInfo {
-                    payment_address: info.sender.clone(),
+                royalty_info: Some(RoyaltyInfoResponse {
+                    payment_address: info.sender.to_string(),
                     share: Decimal::percent(10),
                 }),
             },
@@ -360,8 +360,8 @@ fn initialization() {
                 description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
-                royalties: Some(RoyaltyInfo {
-                    payment_address: info.sender.clone(),
+                royalty_info: Some(RoyaltyInfoResponse {
+                    payment_address: info.sender.to_string(),
                     share: Decimal::percent(10),
                 }),
             },
@@ -980,8 +980,8 @@ fn test_start_time_before_genesis() {
                 description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
-                royalties: Some(RoyaltyInfo {
-                    payment_address: creator.clone(),
+                royalty_info: Some(RoyaltyInfoResponse {
+                    payment_address: creator.to_string(),
                     share: Decimal::percent(10),
                 }),
             },
@@ -1030,7 +1030,7 @@ fn test_update_start_time() {
                 description: String::from("Stargaze Monkeys"),
                 image: "https://example.com/image.png".to_string(),
                 external_link: Some("https://example.com/external.html".to_string()),
-                royalties: None,
+                royalty_info: None,
             },
         },
     };

--- a/contracts/sg721/schema/collection_info_response.json
+++ b/contracts/sg721/schema/collection_info_response.json
@@ -22,7 +22,7 @@
     "royalty": {
       "anyOf": [
         {
-          "$ref": "#/definitions/RoyaltyInfo"
+          "$ref": "#/definitions/RoyaltyInfoResponse"
         },
         {
           "type": "null"
@@ -31,15 +31,11 @@
     }
   },
   "definitions": {
-    "Addr": {
-      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-      "type": "string"
-    },
     "Decimal": {
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
-    "RoyaltyInfo": {
+    "RoyaltyInfoResponse": {
       "type": "object",
       "required": [
         "payment_address",
@@ -47,7 +43,7 @@
       ],
       "properties": {
         "payment_address": {
-          "$ref": "#/definitions/Addr"
+          "type": "string"
         },
         "share": {
           "$ref": "#/definitions/Decimal"

--- a/contracts/sg721/schema/instantiate_msg.json
+++ b/contracts/sg721/schema/instantiate_msg.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "collection_info": {
-      "$ref": "#/definitions/CollectionInfo"
+      "$ref": "#/definitions/CollectionInfo_for_RoyaltyInfoResponse"
     },
     "minter": {
       "type": "string"
@@ -23,11 +23,7 @@
     }
   },
   "definitions": {
-    "Addr": {
-      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-      "type": "string"
-    },
-    "CollectionInfo": {
+    "CollectionInfo_for_RoyaltyInfoResponse": {
       "type": "object",
       "required": [
         "description",
@@ -46,10 +42,10 @@
         "image": {
           "type": "string"
         },
-        "royalties": {
+        "royalty_info": {
           "anyOf": [
             {
-              "$ref": "#/definitions/RoyaltyInfo"
+              "$ref": "#/definitions/RoyaltyInfoResponse"
             },
             {
               "type": "null"
@@ -62,7 +58,7 @@
       "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
       "type": "string"
     },
-    "RoyaltyInfo": {
+    "RoyaltyInfoResponse": {
       "type": "object",
       "required": [
         "payment_address",
@@ -70,7 +66,7 @@
       ],
       "properties": {
         "payment_address": {
-          "$ref": "#/definitions/Addr"
+          "type": "string"
         },
         "share": {
           "$ref": "#/definitions/Decimal"

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -1,4 +1,4 @@
-use crate::state::{CollectionInfo, RoyaltyInfo};
+use crate::{state::CollectionInfo, ContractError};
 use cosmwasm_std::{Decimal, Empty};
 use cw721_base::msg::QueryMsg as Cw721QueryMsg;
 use schemars::JsonSchema;
@@ -9,13 +9,27 @@ pub struct InstantiateMsg {
     pub name: String,
     pub symbol: String,
     pub minter: String,
-    pub collection_info: CollectionInfo,
+    pub collection_info: CollectionInfo<RoyaltyInfoResponse>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct RoyaltyInfoResponse {
     pub payment_address: String,
     pub share: Decimal,
+}
+
+impl RoyaltyInfoResponse {
+    pub fn share_validate(&self) -> Result<Decimal, ContractError> {
+        if self.share > Decimal::one() {
+            return Err(ContractError::InvalidRoyalities {});
+        }
+
+        if self.share < Decimal::zero() {
+            return Err(ContractError::InvalidRoyalities {});
+        }
+
+        Ok(self.share)
+    }
 }
 
 pub type ExecuteMsg = cw721_base::ExecuteMsg<Empty>;

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -1,5 +1,5 @@
 use crate::state::{CollectionInfo, RoyaltyInfo};
-use cosmwasm_std::Empty;
+use cosmwasm_std::{Decimal, Empty};
 use cw721_base::msg::QueryMsg as Cw721QueryMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -10,6 +10,12 @@ pub struct InstantiateMsg {
     pub symbol: String,
     pub minter: String,
     pub collection_info: CollectionInfo,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct RoyaltyInfoResponse {
+    pub payment_address: String,
+    pub share: Decimal,
 }
 
 pub type ExecuteMsg = cw721_base::ExecuteMsg<Empty>;
@@ -128,5 +134,5 @@ pub struct CollectionInfoResponse {
     pub description: String,
     pub image: String,
     pub external_link: Option<String>,
-    pub royalty: Option<RoyaltyInfo>,
+    pub royalty: Option<RoyaltyInfoResponse>,
 }

--- a/contracts/sg721/src/msg.rs
+++ b/contracts/sg721/src/msg.rs
@@ -20,11 +20,7 @@ pub struct RoyaltyInfoResponse {
 
 impl RoyaltyInfoResponse {
     pub fn share_validate(&self) -> Result<Decimal, ContractError> {
-        if self.share > Decimal::one() {
-            return Err(ContractError::InvalidRoyalities {});
-        }
-
-        if self.share < Decimal::zero() {
+        if self.share > Decimal::one() || self.share < Decimal::zero() {
             return Err(ContractError::InvalidRoyalities {});
         }
 

--- a/contracts/sg721/src/state.rs
+++ b/contracts/sg721/src/state.rs
@@ -1,15 +1,14 @@
-use crate::ContractError;
 use cosmwasm_std::{Addr, Decimal};
 use cw_storage_plus::Item;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct CollectionInfo {
+pub struct CollectionInfo<T> {
     pub description: String,
     pub image: String,
     pub external_link: Option<String>,
-    pub royalties: Option<RoyaltyInfo>,
+    pub royalty_info: Option<T>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -18,19 +17,4 @@ pub struct RoyaltyInfo {
     pub share: Decimal,
 }
 
-impl RoyaltyInfo {
-    // Checks if RoyaltyInfo is valid
-    pub fn is_valid(&self) -> Result<bool, ContractError> {
-        if self.share > Decimal::one() {
-            return Err(ContractError::InvalidRoyalities {});
-        }
-
-        if self.share < Decimal::zero() {
-            return Err(ContractError::InvalidRoyalities {});
-        }
-
-        Ok(true)
-    }
-}
-
-pub const CONFIG: Item<CollectionInfo> = Item::new("config");
+pub const COLLECTION_INFO: Item<CollectionInfo<RoyaltyInfo>> = Item::new("collection_info");


### PR DESCRIPTION
We weren't using `String` for the royalty payment address. This fixes it to be more consistent with the rest of the contracts, and also introduces a separate message type for royalty responses that uses strings instead of `Addr`.