### PR TITLE
Removed unused Env

### DIFF
--- a/contracts/sg721/src/contract.rs
+++ b/contracts/sg721/src/contract.rs
@@ -29,13 +29,13 @@ pub type Sg721Contract<'a> = cw721_base::Cw721Contract<'a, Empty, StargazeMsgWra
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
-    env: Env,
+    _env: Env,
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    let fee_msgs = burn_and_distribute_fee(env, &info, CREATION_FEE)?;
+    let fee_msgs = burn_and_distribute_fee(&info, CREATION_FEE)?;
 
     // cw721 instantiation
     let info = ContractInfoResponse {

--- a/contracts/whitelist/src/contract.rs
+++ b/contracts/whitelist/src/contract.rs
@@ -125,7 +125,7 @@ pub fn instantiate(
         ));
     }
 
-    let fee_msgs = burn_and_distribute_fee(env, &info, creation_fee)?;
+    let fee_msgs = burn_and_distribute_fee(&info, creation_fee)?;
 
     if config.member_limit < config.num_members {
         return Err(ContractError::MembersExceeded {
@@ -160,10 +160,10 @@ pub fn execute(
         ExecuteMsg::AddMembers(msg) => execute_add_members(deps, env, info, msg),
         ExecuteMsg::RemoveMembers(msg) => execute_remove_members(deps, env, info, msg),
         ExecuteMsg::UpdatePerAddressLimit(per_address_limit) => {
-            execute_update_per_address_limit(deps, env, info, per_address_limit)
+            execute_update_per_address_limit(deps, info, per_address_limit)
         }
         ExecuteMsg::IncreaseMemberLimit(member_limit) => {
-            execute_increase_member_limit(deps, env, info, member_limit)
+            execute_increase_member_limit(deps, info, member_limit)
         }
     }
 }
@@ -301,7 +301,6 @@ pub fn execute_remove_members(
 
 pub fn execute_update_per_address_limit(
     deps: DepsMut,
-    _env: Env,
     info: MessageInfo,
     per_address_limit: u32,
 ) -> Result<Response, ContractError> {
@@ -327,7 +326,6 @@ pub fn execute_update_per_address_limit(
 /// Increase member limit. Must include a fee if crossing 1000, 2000, etc member limit.
 pub fn execute_increase_member_limit(
     deps: DepsMut,
-    env: Env,
     info: MessageInfo,
     member_limit: u32,
 ) -> Result<Response, ContractError> {
@@ -357,7 +355,7 @@ pub fn execute_increase_member_limit(
     }
 
     let fee_msgs = if upgrade_fee > 0 {
-        burn_and_distribute_fee(env, &info, upgrade_fee)?
+        burn_and_distribute_fee(&info, upgrade_fee)?
     } else {
         vec![]
     };

--- a/packages/sg-std/src/fees.rs
+++ b/packages/sg-std/src/fees.rs
@@ -1,5 +1,5 @@
 use crate::{create_fund_community_pool_msg, StargazeMsgWrapper, NATIVE_DENOM};
-use cosmwasm_std::{coins, BankMsg, CosmosMsg, Decimal, Env, MessageInfo, Uint128};
+use cosmwasm_std::{coins, BankMsg, CosmosMsg, Decimal, MessageInfo, Uint128};
 use cw_utils::{must_pay, PaymentError};
 use thiserror::Error;
 
@@ -8,7 +8,6 @@ const FEE_BURN_PERCENT: u64 = 50;
 
 type SubMsg = CosmosMsg<StargazeMsgWrapper>;
 pub fn burn_and_distribute_fee(
-    _env: Env,
     info: &MessageInfo,
     fee_amount: u128,
 ) -> Result<Vec<SubMsg>, FeeError> {


### PR DESCRIPTION
Not sure why we were passing around `Env` that wasn't used anywhere.