### PR TITLE
Split Fair Burn into two functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "minter",
  "schemars",
  "serde",
- "sg-std 0.9.1",
+ "sg-std 0.10.0",
  "thiserror",
 ]
 
@@ -594,7 +594,7 @@ dependencies = [
  "schemars",
  "serde",
  "sg-multi-test",
- "sg-std 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-std 0.9.1",
  "sg721",
  "thiserror",
  "url",
@@ -704,7 +704,7 @@ dependencies = [
  "cw4 0.12.1",
  "schemars",
  "serde",
- "sg-std 0.9.1",
+ "sg-std 0.10.0",
  "thiserror",
 ]
 
@@ -809,14 +809,15 @@ dependencies = [
  "cw-multi-test",
  "schemars",
  "serde",
- "sg-std 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-std 0.9.1",
 ]
 
 [[package]]
 name = "sg-std"
 version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4dab81e38da9061bc643a23e97b39bf7a0176989d17420905e642b71b65445"
 dependencies = [
- "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils 0.13.1",
  "cw721",
@@ -828,10 +829,9 @@ dependencies = [
 
 [[package]]
 name = "sg-std"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4dab81e38da9061bc643a23e97b39bf7a0176989d17420905e642b71b65445"
+version = "0.10.0"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
  "cw-utils 0.13.1",
  "cw721",
@@ -863,7 +863,7 @@ dependencies = [
  "cw721-base",
  "schemars",
  "serde",
- "sg-std 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-std 0.9.1",
  "thiserror",
  "url",
 ]
@@ -1041,7 +1041,7 @@ dependencies = [
  "rust_decimal",
  "schemars",
  "serde",
- "sg-std 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sg-std 0.9.1",
  "thiserror",
 ]
 

--- a/packages/sg-std/Cargo.toml
+++ b/packages/sg-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sg-std"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 
 authors = ["Jorge Hernandez <jorge@publicawesome.com>"]

--- a/packages/sg-std/src/lib.rs
+++ b/packages/sg-std/src/lib.rs
@@ -16,7 +16,7 @@ pub type Response = cosmwasm_std::Response<StargazeMsgWrapper>;
 pub type SubMsg = cosmwasm_std::SubMsg<StargazeMsgWrapper>;
 pub type CosmosMsg = cosmwasm_std::CosmosMsg<StargazeMsgWrapper>;
 
-pub use fees::{burn_and_distribute_fee, FeeError};
+pub use fees::{checked_fair_burn, fair_burn, FeeError};
 pub use query::StargazeQuery;
 pub use route::StargazeRoute;
 


### PR DESCRIPTION
Sometimes you want to call Fair Burn when you don't have access to `MessageInfo` (like in Marketplace contract). This adds a function for that.