### PR TITLE
Add developer incentives to Fair Burn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "sg1"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cosmwasm-std",
  "cw-utils 0.13.2",

--- a/packages/sg1/Cargo.toml
+++ b/packages/sg1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sg1"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 authors = ["Shane Vitarana <s@noreply.publicawesome.com>"]

--- a/packages/sg1/README.md
+++ b/packages/sg1/README.md
@@ -4,20 +4,29 @@ Fair Burn is a specification for processing fees in Stargaze, influenced by [EIP
 
 With Fair Burn, a portion of fees are burned, and the remaining portion is distributed to stakers. Currently, 50% is burned, and 50% go to the Community Pool.
 
+NOTE: In a future version, the Community Pool allocation will be distributed to stakers instead.
+
+Fair Burn also includes a way to incentivize custom smart contract development by distributing some of the fee to a developer address. This developer fee is substracted from the amount burned.
+
+For example, if a developer address is provided, 40% fees will be burned, 10% will go to the developer address, and 50% will go to the Community Pool.
+
 ## Governance Parameters
 
 ```rs
-const FEE_BURN_PERCENT: u64 = 50;
+const FEE_BURN_PERCENT: u64 = 50;      // 50%
+const DEV_INCENTIVE_PERCENT: u64 = 10; // 10%
 ```
 
 ## API
 
-Contracts can use Fair Burn via one of the following functions:
+Contracts can use Fair Burn via one of the following functions.
 
 ```rs
 /// Burn and distribute fees and return an error if the fee is not enough
-checked_fair_burn(info: &MessageInfo, fee_amount: u128) -> Result<Vec<SubMsg>, FeeError>
+checked_fair_burn(info: &MessageInfo, fee: u128, developer: Option<Addr>) -> Result<Vec<SubMsg>, FeeError>
 
 /// Burn and distribute fees, assuming the right fee is passed in
-fair_burn(fee_amount: u128) -> Vec<SubMsg>
+fair_burn(fee: u128, developer: Option<Addr>) -> Vec<SubMsg>
 ```
+
+Custom contract developers can pass in a a `developer` address that will receive 10% of all fees.

--- a/packages/sg1/src/lib.rs
+++ b/packages/sg1/src/lib.rs
@@ -1,37 +1,60 @@
-use cosmwasm_std::{coins, BankMsg, CosmosMsg, Decimal, MessageInfo, Uint128};
+use cosmwasm_std::{coins, Addr, BankMsg, CosmosMsg, Decimal, MessageInfo, Uint128};
 use cw_utils::{must_pay, PaymentError};
 use sg_std::{create_fund_community_pool_msg, StargazeMsgWrapper, NATIVE_DENOM};
 use thiserror::Error;
 
 // governance parameters
 const FEE_BURN_PERCENT: u64 = 50;
+const DEV_INCENTIVE_PERCENT: u64 = 10;
 
 type SubMsg = CosmosMsg<StargazeMsgWrapper>;
 
 /// Burn and distribute fees and return an error if the fee is not enough
-pub fn checked_fair_burn(info: &MessageInfo, fee_amount: u128) -> Result<Vec<SubMsg>, FeeError> {
+pub fn checked_fair_burn(
+    info: &MessageInfo,
+    fee: u128,
+    dev: Option<Addr>,
+) -> Result<Vec<SubMsg>, FeeError> {
     let payment = must_pay(info, NATIVE_DENOM)?;
-    if payment.u128() < fee_amount {
-        return Err(FeeError::InsufficientFee(fee_amount, payment.u128()));
+    if payment.u128() < fee {
+        return Err(FeeError::InsufficientFee(fee, payment.u128()));
     };
 
-    Ok(fair_burn(fee_amount))
+    Ok(fair_burn(fee, dev))
 }
 
 /// Burn and distribute fees, assuming the right fee is passed in
-pub fn fair_burn(fee_amount: u128) -> Vec<SubMsg> {
-    // calculate the fee to burn
+pub fn fair_burn(fee: u128, dev: Option<Addr>) -> Vec<SubMsg> {
+    let mut msgs: Vec<SubMsg> = vec![];
+
+    let (burn_percent, dev_fee) = match dev {
+        Some(dev) => {
+            let dev_fee = (Uint128::from(fee) * Decimal::percent(DEV_INCENTIVE_PERCENT)).u128();
+            let msg = BankMsg::Send {
+                to_address: dev.to_string(),
+                amount: coins(dev_fee, NATIVE_DENOM),
+            };
+            msgs.push(SubMsg::Bank(msg));
+            (
+                Decimal::percent(FEE_BURN_PERCENT - DEV_INCENTIVE_PERCENT),
+                dev_fee,
+            )
+        }
+        None => (Decimal::percent(FEE_BURN_PERCENT), 0u128),
+    };
+
     // burn half the fee
-    let burn_percent = Decimal::percent(FEE_BURN_PERCENT);
-    let burn_fee = Uint128::from(fee_amount) * burn_percent;
-    let burn_coin = coins(burn_fee.u128(), NATIVE_DENOM);
-    let fee_burn_msg = BankMsg::Burn { amount: burn_coin };
+    let burn_fee = (Uint128::from(fee) * burn_percent).u128();
+    let burn_coin = coins(burn_fee, NATIVE_DENOM);
+    msgs.push(SubMsg::Bank(BankMsg::Burn { amount: burn_coin }));
 
     // Send other half to community pool
-    let fund_community_pool_msg =
-        create_fund_community_pool_msg(coins(fee_amount - burn_fee.u128(), NATIVE_DENOM));
+    msgs.push(create_fund_community_pool_msg(coins(
+        fee - (burn_fee + dev_fee),
+        NATIVE_DENOM,
+    )));
 
-    return vec![CosmosMsg::Bank(fee_burn_msg), fund_community_pool_msg];
+    msgs
 }
 
 #[derive(Error, Debug, PartialEq)]

--- a/packages/sg1/src/lib.rs
+++ b/packages/sg1/src/lib.rs
@@ -13,21 +13,21 @@ type SubMsg = CosmosMsg<StargazeMsgWrapper>;
 pub fn checked_fair_burn(
     info: &MessageInfo,
     fee: u128,
-    dev: Option<Addr>,
+    developer: Option<Addr>,
 ) -> Result<Vec<SubMsg>, FeeError> {
     let payment = must_pay(info, NATIVE_DENOM)?;
     if payment.u128() < fee {
         return Err(FeeError::InsufficientFee(fee, payment.u128()));
     };
 
-    Ok(fair_burn(fee, dev))
+    Ok(fair_burn(fee, developer))
 }
 
 /// Burn and distribute fees, assuming the right fee is passed in
-pub fn fair_burn(fee: u128, dev: Option<Addr>) -> Vec<SubMsg> {
+pub fn fair_burn(fee: u128, developer: Option<Addr>) -> Vec<SubMsg> {
     let mut msgs: Vec<SubMsg> = vec![];
 
-    let (burn_percent, dev_fee) = match dev {
+    let (burn_percent, dev_fee) = match developer {
         Some(dev) => {
             let dev_fee = (Uint128::from(fee) * Decimal::percent(DEV_INCENTIVE_PERCENT)).u128();
             let msg = BankMsg::Send {

--- a/packages/sg1/src/lib.rs
+++ b/packages/sg1/src/lib.rs
@@ -65,3 +65,35 @@ pub enum FeeError {
     #[error("{0}")]
     Payment(#[from] PaymentError),
 }
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::{coins, Addr, BankMsg};
+
+    use crate::{fair_burn, SubMsg};
+
+    #[test]
+    fn check_fair_burn_no_dev_rewards() {
+        let msgs = fair_burn(1000u128, None);
+        let burn_msg = SubMsg::Bank(BankMsg::Burn {
+            amount: coins(500, "ustars".to_string()),
+        });
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0], burn_msg);
+    }
+
+    #[test]
+    fn check_fair_burn_with_dev_rewards() {
+        let msgs = fair_burn(1000u128, Some(Addr::unchecked("geordi")));
+        let bank_msg = SubMsg::Bank(BankMsg::Send {
+            to_address: "geordi".to_string(),
+            amount: coins(100, "ustars".to_string()),
+        });
+        let burn_msg = SubMsg::Bank(BankMsg::Burn {
+            amount: coins(400, "ustars".to_string()),
+        });
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0], bank_msg);
+        assert_eq!(msgs[1], burn_msg);
+    }
+}


### PR DESCRIPTION
Fair Burn now takes an optional developer address where 10% of fees are distributed.